### PR TITLE
Fix TimeseriesAlignmentView Width Overflow and Ensure Minimum Bar Visibility

### DIFF
--- a/gui/src/app/pages/NwbPage/TimeseriesAlignmentView/TimeseriesAlignmentView.tsx
+++ b/gui/src/app/pages/NwbPage/TimeseriesAlignmentView/TimeseriesAlignmentView.tsx
@@ -169,7 +169,7 @@ const TimeseriesAlignmentView: FunctionComponent<Props> = ({
             item={item}
             startTime={startTime}
             endTime={endTime}
-            width={width}
+            width={width - 4}
           />
         </div>
       ))}
@@ -226,13 +226,10 @@ const TAItemView: FunctionComponent<TAItemViewProps> = ({
   const h1 = 18;
   const h2 = 7;
   const h3 = 15;
-  const p1 =
-    ((item.startTime - (startTime || 0)) /
-      ((endTime || 1) - (startTime || 0))) *
-    width;
-  const p2 =
-    ((item.endTime - (startTime || 0)) / ((endTime || 1) - (startTime || 0))) *
-    width;
+  const rawP1 = ((item.startTime - (startTime || 0)) / ((endTime || 1) - (startTime || 0))) * width;
+  const rawP2 = ((item.endTime - (startTime || 0)) / ((endTime || 1) - (startTime || 0))) * width;
+  const p1 = Math.min(Math.max(rawP1, 0), width);
+  const p2 = Math.min(Math.max(rawP2, 0), width);
   const color = getColorForNeurodataType(item.neurodataType);
   const { openTab } = useNwbOpenTabs();
   if (item.startTime === undefined)
@@ -261,7 +258,7 @@ const TAItemView: FunctionComponent<TAItemViewProps> = ({
         style={{
           position: "absolute",
           left: p1,
-          width: p2 - p1,
+          width: Math.max(p2 - p1, 2),
           height: h2,
           top: h1,
           background: color,


### PR DESCRIPTION
fix #218 

This PR makes two key adjustments in the TimeSeriesAlignmentView component:

The width passed to each TAItemView is now reduced by 4 pixels (changed from “width={width}” to “width={width - 4}”) to ensure that the entire view fits within the available window width and prevents any overflow of timeseries items.

Within the TAItemView component, the width of each time bar is computed as “Math.max(p2 - p1, 2)”. This change ensures that even when the computed width (p2 - p1) is very small or zero, a minimum bar width of 2 pixels is enforced so that the bar remains visible and the user can see at least a minimal representation of the timeseries.

Testing:
• Verified locally by running the development server and navigating to the NWB page—the updated view now fits properly within the window, and all time bars are visible with a minimum width of 2 pixels.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/8cb27a0b-293a-47ab-a4a0-4aec51b5ea9a" />
