### PR TITLE
Hide channels line when only one channel is present

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The following table provides example visualizations of different neurodata types
 | ElectricalSeries | neurodata_type: ElectricalSeries | 000409 | [View](https://v2.neurosift.app/nwb?url=https://api.dandiarchive.org/api/assets/37ca1798-b14c-4224-b8f0-037e27725336/download/&dandisetId=000409&dandisetVersion=draft&tab=/acquisition/ElectricalSeriesAp) |
 | TimeIntervals/Units/PSTH | /intervals/trials | 000409 | [View](https://v2.neurosift.app/nwb?url=https://api.dandiarchive.org/api/assets/37ca1798-b14c-4224-b8f0-037e27725336/download/&dandisetId=000409&dandisetVersion=draft&tab=view:PSTH%7C/intervals/trials^/units) |
 | SpatialSeries | pupil_location_spherical | 000728 | [View](https://v2.neurosift.app/nwb?url=https://api.dandiarchive.org/api/assets/a081de4c-ba98-4ba1-b828-9a8b0eeaccfd/download/&dandisetId=000728&dandisetVersion=0.240827.1809&tab=/processing/behavior/CompassDirection/pupil_location_spherical) |
+| LabeledEvents | RewardEventsLinearTrack | 000568 | [View](https://v2.neurosift.app/nwb?url=https://api.dandiarchive.org/api/assets/72bebc59-e73e-4d6b-b4ab-086d054583d6/download/&dandisetId=000568&dandisetVersion=0.230705.1633&tab=/processing/behavior/RewardEventsLinearTrack) |
 
 URL Structure:
 ```


### PR DESCRIPTION
Fixes #232

When viewing timeseries data with only a single channel, the UI previously showed unnecessary channel controls. This PR modifies the SimpleTimeseriesView component to only display the channels section when there is more than one channel.

Changes:
- Added conditional rendering around the channels section in SimpleTimeseriesView
- Channel controls are now only shown when `totalNumChannels > 1`

This improves the UI by removing unnecessary information when viewing single-channel data.