### PR TITLE
Fix timeseries channel count handling for non-power-of-2 numbers

### DIFF
--- a/src/pages/NwbPage/plugins/simple-timeseries/Controls.tsx
+++ b/src/pages/NwbPage/plugins/simple-timeseries/Controls.tsx
@@ -122,7 +122,7 @@ export const Controls: FunctionComponent<ControlsProps> = ({
               <ControlButton
                 onClick={onIncreaseChannels}
                 disabled={
-                  visibleChannelsStart + numVisibleChannels * 2 >
+                  visibleChannelsStart + numVisibleChannels >=
                   info.totalNumChannels
                 }
               >

--- a/src/pages/NwbPage/plugins/simple-timeseries/SimpleTimeseriesView.tsx
+++ b/src/pages/NwbPage/plugins/simple-timeseries/SimpleTimeseriesView.tsx
@@ -41,14 +41,29 @@ export const SimpleTimeseriesView: FunctionComponent<Props> = ({
   }
 
   const handleIncreaseChannels = () => {
-    const newNumChannels = Math.min(
-      numVisibleChannels * 2,
-      timeseriesClient.numChannels - visibleChannelsStart,
-    );
+    const remainingChannels =
+      timeseriesClient.numChannels - visibleChannelsStart;
+    const nextPowerOfTwo = numVisibleChannels * 2;
+
+    // If next power of 2 exceeds total channels, show all remaining channels
+    const newNumChannels =
+      nextPowerOfTwo > remainingChannels ? remainingChannels : nextPowerOfTwo;
+
     setNumVisibleChannels(newNumChannels);
   };
 
   const handleDecreaseChannels = () => {
+    // If current count is equal to total channels, go to previous power of 2
+    if (numVisibleChannels === timeseriesClient.numChannels) {
+      const prevPowerOfTwo = Math.pow(
+        2,
+        Math.floor(Math.log2(numVisibleChannels - 1)),
+      );
+      setNumVisibleChannels(prevPowerOfTwo);
+      return;
+    }
+
+    // Otherwise divide by 2, but ensure at least 1 channel
     const newNumChannels = Math.max(1, Math.floor(numVisibleChannels / 2));
     setNumVisibleChannels(newNumChannels);
   };


### PR DESCRIPTION
Fixes #238

Previously, when increasing the number of visible channels, the UI only allowed powers of 2 (1->2->4) and would disable the increase button if the next power of 2 exceeded the total number of channels. This meant that with 6 total channels, you could only see 1, 2, or 4 channels.

Changes:
- Modified the channel increase logic to show all remaining channels if the next power of 2 would exceed the total
- Updated the button disabled state to only disable when already showing all channels
- When decreasing from showing all channels, it now goes to the previous power of 2