### PR TITLE
Add condensed mode to SimpleTimeseriesView

### DIFF
--- a/src/pages/NwbPage/NwbObjectView.tsx
+++ b/src/pages/NwbPage/NwbObjectView.tsx
@@ -68,7 +68,7 @@ const NwbObjectView: React.FC<NwbObjectViewProps> = ({
       }
     };
     loadPlugin();
-  }, [path, objectType, nwbUrl, plugin]);
+  }, [path, objectType, nwbUrl, plugin, inMultiView]);
 
   if (loading) {
     return <CircularProgress />;
@@ -105,8 +105,9 @@ const NwbObjectView: React.FC<NwbObjectViewProps> = ({
                 secondaryPaths={secondaryPaths}
                 width={componentWidth}
                 height={componentHeight}
+                condensed={inMultiView}
               />
-              <hr />
+              {!inMultiView && <hr />}
             </div>
           );
         })}

--- a/src/pages/NwbPage/components/MultiTabView.tsx
+++ b/src/pages/NwbPage/components/MultiTabView.tsx
@@ -53,7 +53,7 @@ const MultiTabView: React.FC<MultiTabViewProps> = ({
           >
             {paths.map((path, index) => (
               <div key={path}>
-                {index > 0 && <hr style={{ margin: "20px 0" }} />}
+                {/* {index > 0 && <hr style={{ margin: "20px 0" }} />} */}
                 <NwbObjectView
                   nwbUrl={nwbUrl}
                   path={path}

--- a/src/pages/NwbPage/plugins/SpatialSeries/index.ts
+++ b/src/pages/NwbPage/plugins/SpatialSeries/index.ts
@@ -35,5 +35,5 @@ export const spatialSeriesPlugin: NwbObjectViewPlugin = {
   component: SpatialSeriesPluginView,
   // We need window dimensions since we're displaying a spatial plot
   requiresWindowDimensions: true,
-  showInMultiView: true,
+  showInMultiView: false,
 };

--- a/src/pages/NwbPage/plugins/pluginInterface.ts
+++ b/src/pages/NwbPage/plugins/pluginInterface.ts
@@ -16,6 +16,7 @@ export interface NwbObjectViewPlugin {
     secondaryPaths?: string[];
     width?: number;
     height?: number;
+    condensed?: boolean;
   }>;
   special?: boolean;
   requiresWindowDimensions?: boolean;

--- a/src/pages/NwbPage/plugins/simple-timeseries/Controls.tsx
+++ b/src/pages/NwbPage/plugins/simple-timeseries/Controls.tsx
@@ -48,6 +48,115 @@ type ControlsProps = {
   onIncreaseChannelSeparation: () => void;
 };
 
+export const CondensedControls: FunctionComponent<
+  Omit<
+    ControlsProps,
+    | "channelSeparation"
+    | "onDecreaseChannelSeparation"
+    | "onIncreaseChannelSeparation"
+  >
+> = ({
+  info,
+  visibleChannelsStart,
+  numVisibleChannels,
+  visibleTimeStart,
+  visibleDuration,
+  onDecreaseChannels,
+  onIncreaseChannels,
+  onShiftChannelsLeft,
+  onShiftChannelsRight,
+  onDecreaseVisibleDuration,
+  onIncreaseVisibleDuration,
+  onShiftTimeLeft,
+  onShiftTimeRight,
+}) => {
+  return (
+    <div
+      style={{
+        padding: "6px",
+        marginBottom: "10px",
+        background: "#f5f5f5",
+        borderRadius: "5px",
+        fontFamily: "sans-serif",
+        fontSize: "0.9rem",
+        display: "flex",
+        gap: "16px",
+        alignItems: "center",
+      }}
+    >
+      {info.totalNumChannels > 1 && (
+        <div style={{ display: "flex", gap: "6px", alignItems: "center" }}>
+          <span style={{ fontSize: "0.85rem" }}>
+            Channels {visibleChannelsStart}-
+            {Math.min(
+              visibleChannelsStart + numVisibleChannels,
+              info.totalNumChannels,
+            ) - 1}
+          </span>
+          <ControlButton
+            onClick={onDecreaseChannels}
+            disabled={numVisibleChannels <= 1}
+          >
+            /2
+          </ControlButton>
+          <ControlButton
+            onClick={onIncreaseChannels}
+            disabled={
+              visibleChannelsStart + numVisibleChannels >= info.totalNumChannels
+            }
+          >
+            ×2
+          </ControlButton>
+          <ControlButton
+            onClick={onShiftChannelsLeft}
+            disabled={visibleChannelsStart === 0}
+          >
+            ←
+          </ControlButton>
+          <ControlButton
+            onClick={onShiftChannelsRight}
+            disabled={
+              visibleChannelsStart + numVisibleChannels >= info.totalNumChannels
+            }
+          >
+            →
+          </ControlButton>
+        </div>
+      )}
+
+      {visibleTimeStart !== undefined && visibleDuration !== undefined && (
+        <div style={{ display: "flex", gap: "6px", alignItems: "center" }}>
+          <span style={{ fontSize: "0.85rem" }}>
+            {visibleDuration.toFixed(2)}s @ {visibleTimeStart.toFixed(2)}s
+          </span>
+          <ControlButton
+            onClick={onDecreaseVisibleDuration}
+            disabled={visibleDuration <= 0.2}
+          >
+            /2
+          </ControlButton>
+          <ControlButton onClick={onIncreaseVisibleDuration}>×2</ControlButton>
+          <ControlButton
+            onClick={onShiftTimeLeft}
+            disabled={visibleTimeStart <= info.timeseriesStartTime}
+          >
+            ←
+          </ControlButton>
+          <ControlButton
+            onClick={onShiftTimeRight}
+            disabled={
+              visibleTimeStart + visibleDuration >=
+              info.timeseriesStartTime + info.timeseriesDuration
+            }
+          >
+            →
+          </ControlButton>
+        </div>
+      )}
+    </div>
+  );
+};
+
 export const Controls: FunctionComponent<ControlsProps> = ({
   info,
   visibleChannelsStart,

--- a/src/pages/NwbPage/plugins/simple-timeseries/SimpleTimeseriesView.tsx
+++ b/src/pages/NwbPage/plugins/simple-timeseries/SimpleTimeseriesView.tsx
@@ -1,16 +1,14 @@
 import { FunctionComponent, useState } from "react";
 import { Props } from "./types";
-import { Controls } from "./Controls";
+import { Controls, CondensedControls } from "./Controls";
 import { useTimeseriesData } from "./hooks";
 import TimeseriesPlot from "./TimeseriesPlot";
 import LabeledEventsPlot from "./LabeledEventsPlot";
 import "../common/loadingState.css";
 
-export const SimpleTimeseriesView: FunctionComponent<Props> = ({
-  nwbUrl,
-  path,
-  width,
-}) => {
+export const SimpleTimeseriesView: FunctionComponent<
+  Props & { condensed?: boolean }
+> = ({ nwbUrl, path, width, condensed = false }) => {
   const {
     timeseriesClient,
     error,
@@ -128,24 +126,42 @@ export const SimpleTimeseriesView: FunctionComponent<Props> = ({
   return (
     <div style={{ position: "relative" }}>
       {isLoading && <div className="loadingIndicator">Loading data...</div>}
-      <Controls
-        info={info}
-        visibleChannelsStart={visibleChannelsStart}
-        numVisibleChannels={numVisibleChannels}
-        visibleTimeStart={visibleTimeStart}
-        visibleDuration={visibleDuration}
-        channelSeparation={channelSeparation}
-        onDecreaseChannels={handleDecreaseChannels}
-        onIncreaseChannels={handleIncreaseChannels}
-        onShiftChannelsLeft={handleShiftChannelsLeft}
-        onShiftChannelsRight={handleShiftChannelsRight}
-        onDecreaseVisibleDuration={handleDecreaseVisibleDuration}
-        onIncreaseVisibleDuration={handleIncreaseVisibleDuration}
-        onShiftTimeLeft={handleShiftTimeLeft}
-        onShiftTimeRight={handleShiftTimeRight}
-        onDecreaseChannelSeparation={handleDecreaseChannelSeparation}
-        onIncreaseChannelSeparation={handleIncreaseChannelSeparation}
-      />
+      {condensed ? (
+        <CondensedControls
+          info={info}
+          visibleChannelsStart={visibleChannelsStart}
+          numVisibleChannels={numVisibleChannels}
+          visibleTimeStart={visibleTimeStart}
+          visibleDuration={visibleDuration}
+          onDecreaseChannels={handleDecreaseChannels}
+          onIncreaseChannels={handleIncreaseChannels}
+          onShiftChannelsLeft={handleShiftChannelsLeft}
+          onShiftChannelsRight={handleShiftChannelsRight}
+          onDecreaseVisibleDuration={handleDecreaseVisibleDuration}
+          onIncreaseVisibleDuration={handleIncreaseVisibleDuration}
+          onShiftTimeLeft={handleShiftTimeLeft}
+          onShiftTimeRight={handleShiftTimeRight}
+        />
+      ) : (
+        <Controls
+          info={info}
+          visibleChannelsStart={visibleChannelsStart}
+          numVisibleChannels={numVisibleChannels}
+          visibleTimeStart={visibleTimeStart}
+          visibleDuration={visibleDuration}
+          channelSeparation={channelSeparation}
+          onDecreaseChannels={handleDecreaseChannels}
+          onIncreaseChannels={handleIncreaseChannels}
+          onShiftChannelsLeft={handleShiftChannelsLeft}
+          onShiftChannelsRight={handleShiftChannelsRight}
+          onDecreaseVisibleDuration={handleDecreaseVisibleDuration}
+          onIncreaseVisibleDuration={handleIncreaseVisibleDuration}
+          onShiftTimeLeft={handleShiftTimeLeft}
+          onShiftTimeRight={handleShiftTimeRight}
+          onDecreaseChannelSeparation={handleDecreaseChannelSeparation}
+          onIncreaseChannelSeparation={handleIncreaseChannelSeparation}
+        />
+      )}
       {timeseriesClient.isLabeledEvents() ? (
         <LabeledEventsPlot
           timestamps={info.visibleTimestamps}
@@ -158,6 +174,7 @@ export const SimpleTimeseriesView: FunctionComponent<Props> = ({
           data={info.visibleData}
           channelSeparation={channelSeparation}
           width={width}
+          height={condensed ? 200 : 350}
         />
       )}
     </div>

--- a/src/pages/NwbPage/plugins/simple-timeseries/TimeseriesPlot.tsx
+++ b/src/pages/NwbPage/plugins/simple-timeseries/TimeseriesPlot.tsx
@@ -6,6 +6,7 @@ type Props = {
   data?: number[][];
   channelSeparation?: number; // Factor for channel separation (0 means no separation)
   width?: number;
+  height?: number;
 };
 
 const TimeseriesPlot: FunctionComponent<Props> = ({
@@ -13,6 +14,7 @@ const TimeseriesPlot: FunctionComponent<Props> = ({
   data,
   channelSeparation = 0,
   width,
+  height,
 }) => {
   // Memoize the transposed channel data
   const channelData = useMemo(() => {
@@ -84,7 +86,7 @@ const TimeseriesPlot: FunctionComponent<Props> = ({
       }))}
       layout={{
         width: (width || 700) - 20,
-        height: 400,
+        height: height || 300,
         margin: {
           l: 50,
           r: 20,

--- a/src/pages/NwbPage/plugins/simple-timeseries/types.ts
+++ b/src/pages/NwbPage/plugins/simple-timeseries/types.ts
@@ -14,4 +14,5 @@ export type Props = {
   nwbUrl: string;
   path: string;
   width?: number;
+  condensed?: boolean;
 };


### PR DESCRIPTION
Fixes #243

Adds a condensed mode to SimpleTimeseriesView that displays all controls in a single toolbar above the plot. The mode includes:
- Channel visibility controls (select channels, zoom in/out)
- Time range controls (zoom and pan)

Users can enable condensed mode by passing the `condensed` prop to the component.