### PR TITLE
Fix multi-view tab query parameter support

### DIFF
--- a/src/pages/NwbPage/TabManager/index.ts
+++ b/src/pages/NwbPage/TabManager/index.ts
@@ -60,8 +60,16 @@ export const useTabManager = ({
             plugin,
             secondaryPaths,
           });
+        } else if (initialTabId.startsWith("[")) {
+          const paths = JSON.parse(initialTabId);
+          const objectTypes = await Promise.all(
+            paths.map((path: string) => determineObjectType(nwbUrl, path)),
+          );
+          if (canceled) return;
+          dispatch({ type: "OPEN_MULTI_TAB", paths, objectTypes });
         } else {
           const objectType = await determineObjectType(nwbUrl, initialTabId);
+          if (canceled) return;
           dispatch({
             type: "OPEN_TAB",
             id: initialTabId,


### PR DESCRIPTION
Fixes #245

Adds support for multi-view in tab query parameters. When copying a link for a tab that contains multiple views, the URL parameter is now properly handled by parsing a JSON array of paths and opening them in a multi-tab view.