### PR TITLE
Add toggle for showing all files in dandiset view

### DIFF
--- a/src/pages/DandisetPage/index.tsx
+++ b/src/pages/DandisetPage/index.tsx
@@ -41,12 +41,14 @@ const DandisetPage: FunctionComponent<DandisetPageProps> = ({
   // todo: set dandisetVersion to route if not there yet
 
   const [maxNumPages] = useState(1);
+  const [nwbFilesOnly, setNwbFilesOnly] = useState(false);
   const { assetsResponses, incomplete } = useQueryAssets(
     dandisetId,
     maxNumPages,
     dandisetResponse || null,
     dandisetVersionInfo,
     staging,
+    nwbFilesOnly,
   );
   const allAssets: AssetsResponseItem[] | null = useMemo(() => {
     if (!assetsResponses) return null;
@@ -137,7 +139,34 @@ const DandisetPage: FunctionComponent<DandisetPageProps> = ({
         </div>
 
         <div style={{ marginTop: "20px" }}>
-          <h2>Assets {incomplete && "(showing partial list)"}</h2>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: "10px",
+              marginBottom: "10px",
+            }}
+          >
+            <h2 style={{ margin: 0 }}>
+              Assets {incomplete && "(showing partial list)"}
+            </h2>
+            <label
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "5px",
+                fontSize: "14px",
+                cursor: "pointer",
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={nwbFilesOnly}
+                onChange={(e) => setNwbFilesOnly(e.target.checked)}
+              />
+              Show NWB files only
+            </label>
+          </div>
           <div style={{ marginBottom: "10px" }}>
             Total files:{" "}
             {dandisetVersionInfo.metadata.assetsSummary.numberOfFiles}

--- a/src/pages/DandisetPage/useQueryAssets.ts
+++ b/src/pages/DandisetPage/useQueryAssets.ts
@@ -13,6 +13,7 @@ export const useQueryAssets = (
   dandisetResponse: DandisetSearchResultItem | null,
   dandisetVersionInfo: DandisetVersionInfo | null,
   useStaging: boolean | undefined,
+  nwbFilesOnly: boolean = false,
 ): {
   incomplete: boolean;
   assetsResponses: AssetsResponse[] | null;
@@ -31,8 +32,9 @@ export const useQueryAssets = (
     (async () => {
       let rr: AssetsResponse[] = [];
       const stagingStr = useStaging ? "-staging" : "";
+      const globFilter = nwbFilesOnly ? "&glob=*.nwb*" : "";
       let uu: string | null =
-        `https://api${stagingStr}.dandiarchive.org/api/dandisets/${dandisetId}/versions/${dandisetVersionInfo.version}/assets/?page_size=1000&glob=*.nwb*`;
+        `https://api${stagingStr}.dandiarchive.org/api/dandisets/${dandisetId}/versions/${dandisetVersionInfo.version}/assets/?page_size=1000${globFilter}`;
       const authorizationHeader = uu ? getAuthorizationHeaderForUrl(uu) : "";
       const headers = authorizationHeader
         ? { Authorization: authorizationHeader }
@@ -68,6 +70,7 @@ export const useQueryAssets = (
     maxNumPages,
     dandisetVersionInfo,
     setIncomplete,
+    nwbFilesOnly,
   ]);
   return { incomplete, assetsResponses };
 };


### PR DESCRIPTION
Fixes #247

Added a toggle to switch between showing all files or NWB files only in the dandiset view:
- Added nwbFilesOnly parameter to useQueryAssets
- Added UI toggle in DandisetPage
- Default is to show all files

The toggle allows users to easily switch between viewing all files or just NWB files, providing flexibility while maintaining the ability to focus on NWB files when needed.