### PR TITLE
fix #253: improve raster plot unit visualization for non-power-of-2 counts

### DIFF
--- a/src/pages/NwbPage/plugins/Raster/RasterView.tsx
+++ b/src/pages/NwbPage/plugins/Raster/RasterView.tsx
@@ -95,14 +95,31 @@ const RasterViewChild = ({
 
   const handleIncreaseUnits = () => {
     if (!spikeTrainsClient) return;
-    const newNumUnits = Math.min(
-      numVisibleUnits * 2,
-      spikeTrainsClient.unitIds.length - visibleUnitsStart,
-    );
+    const remainingUnits = spikeTrainsClient.unitIds.length - visibleUnitsStart;
+    if (numVisibleUnits === remainingUnits) return; // Already showing all units
+
+    const nextPowerOfTwo = numVisibleUnits * 2;
+    // If next power of 2 exceeds remaining units, show all remaining units
+    const newNumUnits =
+      nextPowerOfTwo > remainingUnits ? remainingUnits : nextPowerOfTwo;
     setNumVisibleUnits(newNumUnits);
   };
 
   const handleDecreaseUnits = () => {
+    if (!spikeTrainsClient) return;
+    // If current count is equal to total units, go to previous power of 2
+    if (
+      numVisibleUnits ===
+      spikeTrainsClient.unitIds.length - visibleUnitsStart
+    ) {
+      const prevPowerOfTwo = Math.pow(
+        2,
+        Math.floor(Math.log2(numVisibleUnits - 1)),
+      );
+      setNumVisibleUnits(prevPowerOfTwo);
+      return;
+    }
+    // Otherwise divide by 2, but ensure at least 1 unit
     const newNumUnits = Math.max(1, Math.floor(numVisibleUnits / 2));
     setNumVisibleUnits(newNumUnits);
   };
@@ -196,7 +213,7 @@ const RasterViewChild = ({
             <button
               onClick={handleIncreaseUnits}
               disabled={
-                visibleUnitsStart + numVisibleUnits * 2 > plotData.totalNumUnits
+                visibleUnitsStart + numVisibleUnits >= plotData.totalNumUnits
               }
               style={{
                 padding: "2px 6px",


### PR DESCRIPTION
Fixed issue where raster plot could not show all units when the total count was not a power of 2. Implemented the same approach used in simple-timeseries view:

- When increasing units beyond a power of 2, shows all remaining units instead of staying limited to powers of 2
- When decreasing from showing all units, drops down to previous power of 2
- Otherwise maintains power of 2 increments for unit display

Fixes #253