### PR TITLE
Add authentication error handling and notification for embargoed datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## May 12, 2025
+- Added permission error notification for embargoed DANDI datasets (Issue #297)
+  - Added error detection for unauthorized access attempts
+  - Added UI notification with guidance on how to provide API key credentials
+  - Added direct links to settings page and DANDI archive for obtaining API keys
+
 ## April 13, 2025
 - Fixed TimeIntervals widget to properly render when no categorical columns are available (Issue #302)
 

--- a/src/pages/NwbPage/MainWorkspace.tsx
+++ b/src/pages/NwbPage/MainWorkspace.tsx
@@ -1,11 +1,13 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { TabBar } from "@components/tabs/TabBar";
 import { TAB_BAR_HEIGHT } from "./tabStyles";
 import { useTabManager } from "./TabManager";
 import TabContent from "./components/TabContent";
 import SingleTabView from "./components/SingleTabView";
 import MultiTabView from "./components/MultiTabView";
-import { DynamicTab } from "./Types";
+import AuthErrorNotification from "./components/AuthErrorNotification";
+import { DynamicTab } from "./Types/index";
+import { hasAuthError, isDandiAssetUrl } from "./hdf5Interface";
 
 interface MainWorkspaceProps {
   nwbUrl: string;
@@ -27,12 +29,56 @@ const MainWorkspace: React.FC<MainWorkspaceProps> = ({
     handleCloseTab,
     handleSwitchTab,
   } = useTabManager({ nwbUrl, initialTabId });
+  
+  const [showAuthError, setShowAuthError] = useState(false);
 
   const tabBarHeight = TAB_BAR_HEIGHT;
   const contentHeight = height - tabBarHeight;
+  
+  // Check for authentication errors
+  useEffect(() => {
+    if (nwbUrl) {
+      const checkAuthError = () => {
+        const hasError = hasAuthError(nwbUrl);
+        setShowAuthError(hasError);
+      };
+      
+      // Check immediately
+      checkAuthError();
+      
+      // Also set up interval to periodically check for auth errors as they might
+      // be detected during data loading after component mount
+      const intervalId = setInterval(checkAuthError, 1000);
+      
+      return () => {
+        clearInterval(intervalId);
+      };
+    }
+  }, [nwbUrl]);
+
+  // Debug logs
+  useEffect(() => {
+    if (isDandiAssetUrl(nwbUrl)) {
+      console.log('MainWorkspace - DANDI URL detected:', nwbUrl);
+      console.log('MainWorkspace - Current auth errors:', hasAuthError(nwbUrl));
+    }
+  }, [nwbUrl, showAuthError]);
 
   return (
     <div style={{ position: "absolute", width, height, overflow: "hidden" }}>
+      {/* Error notification as overlay */}
+      {showAuthError && isDandiAssetUrl(nwbUrl) && (
+        <div style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          zIndex: 1000,
+        }}>
+          <AuthErrorNotification dandiUrl={nwbUrl} />
+        </div>
+      )}
+      
       <TabBar
         tabs={tabsState.tabs}
         activeTabId={tabsState.activeTabId}

--- a/src/pages/NwbPage/NwbPage.tsx
+++ b/src/pages/NwbPage/NwbPage.tsx
@@ -13,7 +13,10 @@ import "@css/NwbPage.css";
 import { TAB_BAR_HEIGHT, tabsStyle, tabStyle } from "./tabStyles";
 import { useNwbFileOverview } from "./useNwbFileOverview";
 import { track } from "@vercel/analytics/react";
-import { setCurrentDandisetId, setTryUsingLindi } from "@hdf5Interface";
+import { 
+  setCurrentDandisetId, 
+  setTryUsingLindi, 
+} from "@hdf5Interface";
 
 type NwbPageProps = {
   width: number;

--- a/src/pages/NwbPage/components/AuthErrorNotification.tsx
+++ b/src/pages/NwbPage/components/AuthErrorNotification.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { Alert, Button, Box, Link } from "@mui/material";
+import { useNavigate } from "react-router-dom";
+
+interface AuthErrorNotificationProps {
+  dandiUrl?: string;
+}
+
+const AuthErrorNotification: React.FC<AuthErrorNotificationProps> = ({ dandiUrl }) => {
+  const navigate = useNavigate();
+  
+  const isDandiStaging = dandiUrl?.includes("api-staging.dandiarchive.org");
+  const serverType = isDandiStaging ? "DANDI Staging" : "DANDI";
+
+  return (
+    <Box sx={{ m: 2 }}>
+      <Alert 
+        severity="warning"
+        sx={{ 
+          mb: 2,
+          "& .MuiAlert-message": { 
+            width: "100%" 
+          }
+        }}
+      >
+        <Box>
+          <strong>Permission Required</strong>
+          <p>
+            This appears to be an embargoed dataset that requires authentication to access.
+            You need to provide a valid {serverType} API key in your settings.
+          </p>
+          <Box sx={{ mt: 2, display: "flex", gap: 2 }}>
+            <Button 
+              variant="contained" 
+              color="primary"
+              size="small"
+              onClick={() => navigate("/settings")}
+            >
+              Go to Settings
+            </Button>
+            <Button
+              variant="outlined"
+              size="small"
+              component={Link}
+              href={isDandiStaging ? "https://gui-staging.dandiarchive.org" : "https://dandiarchive.org"}
+              target="_blank"
+            >
+              Get API Key from {serverType}
+            </Button>
+          </Box>
+        </Box>
+      </Alert>
+    </Box>
+  );
+};
+
+export default AuthErrorNotification;

--- a/src/pages/NwbPage/hdf5Interface.ts
+++ b/src/pages/NwbPage/hdf5Interface.ts
@@ -18,6 +18,11 @@ const hdf5Files: {
   };
 } = {};
 
+// Authentication error tracking
+export const authenticationErrors: {
+  [url: string]: boolean;
+} = {};
+
 // for looking up lindi files
 let currentDandisetId = "";
 export const setCurrentDandisetId = (dandisetId: string) => {
@@ -26,6 +31,52 @@ export const setCurrentDandisetId = (dandisetId: string) => {
 let tryUsingLindi = true;
 export const setTryUsingLindi = (val: boolean) => {
   tryUsingLindi = val;
+};
+
+export const hasAuthError = (url: string): boolean => {
+  // Direct match
+  if (authenticationErrors[url]) {
+    return true;
+  }
+  
+  // If we get a direct URL but the stored error might be from the pre-redirection URL
+  const keys = Object.keys(authenticationErrors);
+  for (const key of keys) {
+    // Look for a URL that has the same asset ID 
+    if (url.includes('/assets/') && key.includes('/assets/')) {
+      const urlAssetId = url.split('/assets/')[1]?.split('/')[0];
+      const keyAssetId = key.split('/assets/')[1]?.split('/')[0];
+      
+      if (urlAssetId && keyAssetId && urlAssetId === keyAssetId) {
+        console.log('Asset ID match found for auth error:', urlAssetId);
+        return true;
+      }
+    }
+  }
+  
+  return false;
+};
+
+export const clearAuthError = (url: string): void => {
+  if (authenticationErrors[url]) {
+    delete authenticationErrors[url];
+    return;
+  }
+  
+  // Also try to clear by asset ID
+  if (url.includes('/assets/')) {
+    const urlAssetId = url.split('/assets/')[1]?.split('/')[0];
+    const keys = Object.keys(authenticationErrors);
+    
+    for (const key of keys) {
+      if (key.includes('/assets/')) {
+        const keyAssetId = key.split('/assets/')[1]?.split('/')[0];
+        if (urlAssetId && keyAssetId && urlAssetId === keyAssetId) {
+          delete authenticationErrors[key];
+        }
+      }
+    }
+  }
 };
 export const isUsingLindi = (url: string) => {
   return hdf5Files[url]?.resolvedUrl.endsWith(".lindi.json");
@@ -356,12 +407,32 @@ export const getRedirectUrl = async (url: string, headers: any) => {
   // and then look at the Location response header.
   // However, we run into mysterious cors problems
   // So instead, we do a HEAD request with no redirect option, and then look at the response.url
-  const response = await headRequest(url, headers);
-  if (response.url) {
-    const redirectUrl = response.url;
-    return redirectUrl;
-  } else {
-    console.warn(`No redirect for ${url}`);
+  try {
+    const response = await headRequest(url, headers);
+    
+    // Check for authentication errors (typically 401 or 403)
+    if (response.status === 401 || response.status === 403) {
+      console.warn(`Authentication error for ${url}: ${response.status}`);
+      authenticationErrors[url] = true;
+      console.log('Authentication errors map:', authenticationErrors);
+    } else if (response.ok) {
+      // Clear any previous auth errors if the request succeeded
+      delete authenticationErrors[url];
+    }
+    
+    if (response.url) {
+      const redirectUrl = response.url;
+      return redirectUrl;
+    } else {
+      console.warn(`No redirect for ${url}`);
+      return null;
+    }
+  } catch (error) {
+    console.error(`Error during request for ${url}:`, error);
+    // If we're getting network errors with embargoed content, mark as auth error
+    if (isDandiAssetUrl(url) && !headers?.Authorization) {
+      authenticationErrors[url] = true;
+    }
     return null;
   }
 


### PR DESCRIPTION

<img width="1472" alt="image" src="https://github.com/user-attachments/assets/29ae35ea-b505-4b52-95fc-b8768f6917e5" />

fix #297 

- Implemented AuthErrorNotification component to inform users about permission requirements for embargoed datasets.
- Integrated authentication error checks in MainWorkspace and hdf5Interface.
- Updated CHANGELOG with new features and improvements.