### PR TITLE
PSTH group-by fix

### DIFF
--- a/src/pages/NwbPage/plugins/PSTH/PSTHItemView/components/GroupBySelection.tsx
+++ b/src/pages/NwbPage/plugins/PSTH/PSTHItemView/components/GroupBySelection.tsx
@@ -48,7 +48,9 @@ const GroupBySelectionComponent: FunctionComponent<GroupBySelectionProps> = ({
         if (!ds) continue;
         if (ds.shape.length !== 1) continue;
         const slice =
-          ds.shape[0] < 1000 ? undefined : ([[0, 1000]] as [number, number][]); // just check the first 1000 values
+          ds.shape[0] < 10000
+            ? undefined
+            : ([[0, 10000]] as [number, number][]); // just check the first values
         const dd = await getHdf5DatasetData(nwbUrl, path + "/" + option, {
           slice,
         });


### PR DESCRIPTION
Fixes #349 

However, I didn't solve the root of the problem. For some reason, mysteriously, reading the first 1000 values of /intervals/trials/odorant was failing, and I couldn't track down why. So I increased 1000 to 10000 and then things started working. This is probably an edge case for the hdf5 driver for datasets of type string.

Working for now, but this type of issue may crop up again at some point.