### PR TITLE
Update file linking method for Windows compatibility

### DIFF
--- a/python/neurosift/cli.py
+++ b/python/neurosift/cli.py
@@ -6,7 +6,8 @@ import webbrowser
 import socket
 from contextlib import closing
 from .TemporaryDirectory import TemporaryDirectory
-
+import shutil
+import sys
 
 @click.group()
 def neurosift():
@@ -24,8 +25,12 @@ def view_nwb(file: str, neurosift_url: str):
     abs_fname = os.path.abspath(file)
     base_fname = os.path.basename(abs_fname)
     with TemporaryDirectory(prefix="view_nwb") as tmpdir:
-        # create a symbolic link to the file (or zarr folder)
-        os.symlink(abs_fname, f"{tmpdir}/{base_fname}")
+        if sys.platform == 'win32':
+            # symlinks require admin priviledge on Windows - do a copy instead
+            shutil.copy2(abs_fname, f'{tmpdir}/{base_fname}')
+        else:
+            # create a symbolic link to the file (or zarr folder)
+            os.symlink(abs_fname, f'{tmpdir}/{base_fname}')
 
         # this directory
         this_directory = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
Modify file handling to use copy on Windows. 
Tested and working - but then we get an extra copy of the original file. Also, no idea where the temp file is. 
Could it be done in-place instead?