### PR TITLE
Render Specifications JSON columns as formatted JSON

### DIFF
--- a/src/components/ExpandableTableCell.tsx
+++ b/src/components/ExpandableTableCell.tsx
@@ -3,18 +3,56 @@ import { FunctionComponent, useState } from "react";
 interface ExpandableTableCellProps {
   content: string;
   maxLength?: number;
+  preformatted?: boolean;
 }
 
 const ExpandableTableCell: FunctionComponent<ExpandableTableCellProps> = ({
   content,
   maxLength = 60,
+  preformatted = false,
 }) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
   if (!content) return <span></span>;
 
-  if (content.length <= maxLength || isExpanded) {
-    return <span>{content}</span>;
+  if (content.length <= maxLength) {
+    return preformatted ? (
+      <pre style={{ margin: 0, fontFamily: "monospace", fontSize: "0.9em" }}>
+        {content}
+      </pre>
+    ) : (
+      <span>{content}</span>
+    );
+  }
+
+  if (isExpanded) {
+    return (
+      <div>
+        {preformatted ? (
+          <pre
+            style={{ margin: 0, fontFamily: "monospace", fontSize: "0.9em" }}
+          >
+            {content}
+          </pre>
+        ) : (
+          <span>{content}</span>
+        )}
+        <button
+          onClick={() => setIsExpanded(false)}
+          style={{
+            marginTop: "4px",
+            background: "white",
+            border: "1px solid #ccc",
+            borderRadius: "3px",
+            padding: "2px 5px",
+            fontSize: "0.8em",
+            cursor: "pointer",
+          }}
+        >
+          Collapse
+        </button>
+      </div>
+    );
   }
 
   return (
@@ -23,30 +61,11 @@ const ExpandableTableCell: FunctionComponent<ExpandableTableCellProps> = ({
         onClick={() => setIsExpanded(!isExpanded)}
         style={{
           cursor: "pointer",
-          color: !isExpanded ? "#0d47a1" : undefined,
+          color: "#0d47a1",
         }}
       >
-        {isExpanded ? content : `${content.slice(0, maxLength - 3)}...`}
+        {`${content.slice(0, maxLength - 3)}...`}
       </span>
-      {isExpanded && (
-        <button
-          onClick={() => setIsExpanded(false)}
-          style={{
-            position: "absolute",
-            right: 0,
-            top: "100%",
-            background: "white",
-            border: "1px solid #ccc",
-            borderRadius: "3px",
-            padding: "2px 5px",
-            fontSize: "0.8em",
-            cursor: "pointer",
-            zIndex: 1000,
-          }}
-        >
-          Collapse
-        </button>
-      )}
     </div>
   );
 };

--- a/src/pages/NwbPage/SpecificationsView/SpecificationsView.tsx
+++ b/src/pages/NwbPage/SpecificationsView/SpecificationsView.tsx
@@ -129,13 +129,22 @@ const SpecificationsView: FunctionComponent<SpecificationsViewProps> = () => {
               </td>
               <td>{ds.neurodata_type_inc}</td>
               <td>
-                <ExpandableTableCell content={JSON.stringify(ds.dtype)} />
+                <ExpandableTableCell
+                  content={JSON.stringify(ds.dtype, null, 2)}
+                  preformatted
+                />
               </td>
               <td>
-                <ExpandableTableCell content={JSON.stringify(ds.dims)} />
+                <ExpandableTableCell
+                  content={JSON.stringify(ds.dims, null, 2)}
+                  preformatted
+                />
               </td>
               <td>
-                <ExpandableTableCell content={JSON.stringify(ds.attributes)} />
+                <ExpandableTableCell
+                  content={JSON.stringify(ds.attributes, null, 2)}
+                  preformatted
+                />
               </td>
             </tr>
           ))}
@@ -167,10 +176,16 @@ const SpecificationsView: FunctionComponent<SpecificationsViewProps> = () => {
                 <ExpandableTableCell content={g.doc} />
               </td>
               <td>
-                <ExpandableTableCell content={JSON.stringify(g.datasets)} />
+                <ExpandableTableCell
+                  content={JSON.stringify(g.datasets, null, 2)}
+                  preformatted
+                />
               </td>
               <td>
-                <ExpandableTableCell content={JSON.stringify(g.groups)} />
+                <ExpandableTableCell
+                  content={JSON.stringify(g.groups, null, 2)}
+                  preformatted
+                />
               </td>
             </tr>
           ))}


### PR DESCRIPTION
## Summary
- Add `preformatted` prop to `ExpandableTableCell` to render JSON content in `<pre>` tags with monospace font
- Use pretty-printed `JSON.stringify(x, null, 2)` for datasets (dtype, dims, attributes) and groups (datasets, groups) columns in Specifications view
- Fix Collapse button positioning to be inline instead of absolutely positioned outside the cell

## Test plan
- [ ] Open Specifications tab on an NWB file
- [ ] Verify JSON columns (dtype, dims, attributes, datasets, groups) display formatted JSON
- [ ] Verify expand/collapse works and the Collapse button is visible within the cell

🤖 Generated with [Claude Code](https://claude.com/claude-code)