### PR TITLE
Visually distinguish neurodata types with interactive views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changes
 
+## March 13, 2026
+
+- Show dataset chunking and compression in HDF5 view
+
+## March 9, 2026
+
+- Add LINDI LocalCache to generated Python scripts
+
+## January 27, 2026
+
+- Update NIfTI warning statement for files larger than 100 MB
+- Standardize `NIFTI` naming to `NIfTI`
+
 ## November 24, 2025
 
 - Added combined time controller for SpatialSeries view with editable duration/start time fields, zoom/pan buttons, and graphical time bar on a single horizontal line

--- a/src/css/NwbHierarchyView.css
+++ b/src/css/NwbHierarchyView.css
@@ -39,6 +39,17 @@
     font-size: 0.8rem;
 }
 
+/* Neurodata type with an interactive data view */
+.neurodata-type-interactive {
+    color: #1565c0;
+    font-weight: 500;
+}
+
+/* Neurodata type with only the generic fallback view */
+.neurodata-type-generic {
+    color: #aaa;
+}
+
 /* Checkbox styling */
 .nwb-hierarchy-table input[type="checkbox"] {
     margin: 0;

--- a/src/pages/NwbPage/NwbHierarchyView.tsx
+++ b/src/pages/NwbPage/NwbHierarchyView.tsx
@@ -46,6 +46,8 @@ const NwbHierarchyView: FunctionComponent<Props> = ({
   ] = useState<{
     [key: string]: { plugin: NwbObjectViewPlugin; secondaryPaths: string[] }[];
   }>({});
+  const [objectsWithInteractiveViews, setObjectsWithInteractiveViews] =
+    useState<Set<string> | null>(null);
 
   // if any objects have only a single child, and their parent is visibly expanded, expand the object
   useEffect(() => {
@@ -118,6 +120,30 @@ const NwbHierarchyView: FunctionComponent<Props> = ({
     loadLaunchablePlugins();
   }, [nwbUrl, neurodataObjects, defaultUnitsPath]);
 
+  useEffect(() => {
+    const checkInteractiveViews = async () => {
+      const interactivePaths = new Set<string>();
+      for (const obj of neurodataObjects) {
+        if (!obj.attrs.neurodata_type) continue;
+        const objectType = obj.group ? "group" : "dataset";
+        const plugins = await findSuitablePlugins(
+          nwbUrl,
+          obj.path,
+          objectType,
+          { specifications },
+        );
+        const hasInteractive = plugins.some(
+          (p) => p.name !== "default" && p.name !== "PythonScript",
+        );
+        if (hasInteractive) {
+          interactivePaths.add(obj.path);
+        }
+      }
+      setObjectsWithInteractiveViews(interactivePaths);
+    };
+    checkInteractiveViews();
+  }, [nwbUrl, neurodataObjects, specifications]);
+
   const truncateDescription = useCallback(
     (text: string, path: string) => {
       if (!text) return "";
@@ -142,6 +168,7 @@ const NwbHierarchyView: FunctionComponent<Props> = ({
                 color: "#007bff",
                 cursor: "pointer",
                 fontSize: "0.9em",
+                whiteSpace: "nowrap",
               }}
             >
               show less
@@ -167,6 +194,7 @@ const NwbHierarchyView: FunctionComponent<Props> = ({
               color: "#007bff",
               cursor: "pointer",
               fontSize: "0.9em",
+              whiteSpace: "nowrap",
             }}
           >
             read more
@@ -373,7 +401,24 @@ const NwbHierarchyView: FunctionComponent<Props> = ({
         </td>
         <td>
           <div style={{ display: "flex", alignItems: "center", gap: "5px" }}>
-            <span>{obj.attrs.neurodata_type || "-"}</span>
+            <span
+              className={
+                obj.attrs.neurodata_type && objectsWithInteractiveViews
+                  ? objectsWithInteractiveViews.has(obj.path)
+                    ? "neurodata-type-interactive"
+                    : "neurodata-type-generic"
+                  : undefined
+              }
+              title={
+                obj.attrs.neurodata_type && objectsWithInteractiveViews
+                  ? objectsWithInteractiveViews.has(obj.path)
+                    ? "Has interactive data view"
+                    : "No dedicated view available"
+                  : undefined
+              }
+            >
+              {obj.attrs.neurodata_type || "-"}
+            </span>
             {obj.attrs.neurodata_type === "Units" && (
               <span
                 onClick={(e) => {


### PR DESCRIPTION
## Summary
- Neurodata types with dedicated interactive data views (e.g. TimeSeries, Units, DynamicTable) now appear in **blue** in the hierarchy table, while types with only the generic fallback view appear in **muted gray**
- Tooltips on hover explain whether a dedicated view is available
- Fixed "read more"/"show less" description links wrapping to a second line

## Test plan
- [ ] Open an NWB file and verify that types like `ElectricalSeries`, `Units`, `TimeIntervals` show in blue
- [ ] Verify that types like `NWBFile`, `Subject`, `Device` show in muted gray
- [ ] Hover over neurodata types to confirm tooltips appear
- [ ] Confirm "read more" links stay on one line with long descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)