### PR TITLE
Fix invalid char in python usage script

### DIFF
--- a/nextjs/neurosift-chat-agent-tools/src/lib/tools/createUsageScriptForNwbFile.ts
+++ b/nextjs/neurosift-chat-agent-tools/src/lib/tools/createUsageScriptForNwbFile.ts
@@ -361,7 +361,7 @@ const createUsageScriptForNwbFile = async (nwbUrl: string) => {
         s += `${obj.variableName}.indexed_images # Images\n`;
         s += `for k in ${obj.variableName}.indexed_images.images.keys():\n`;
         s += `    image = ${obj.variableName}.indexed_images.images[k]\n`;
-        s += `    print(f'Image {k}: {image.data.shape})')\n`;
+        s += `    print(f'Image {k}: {image.data.shape}')\n`;
       }
     }
 

--- a/src/pages/NwbPage/components/createUsageScriptForNwbFile.ts
+++ b/src/pages/NwbPage/components/createUsageScriptForNwbFile.ts
@@ -362,7 +362,7 @@ const createUsageScriptForNwbFile = async (nwbUrl: string) => {
         s += `${obj.variableName}.indexed_images # Images\n`;
         s += `for k in ${obj.variableName}.indexed_images.images.keys():\n`;
         s += `    image = ${obj.variableName}.indexed_images.images[k]\n`;
-        s += `    print(f'Image {k}: {image.data.shape})')\n`;
+        s += `    print(f'Image {k}: {image.data.shape}')\n`;
       }
     }
 

--- a/src/remote-h5-file/lib/lindi/zarrDecodeChunkArray.ts
+++ b/src/remote-h5-file/lib/lindi/zarrDecodeChunkArray.ts
@@ -96,9 +96,10 @@ const zarrDecodeChunkArray = async (
       const ret2 = [];
       for (let i = 0; i < nn; i++) {
         const ret1 = new Uint32Array(ret, i * fixedLength * 4, fixedLength);
-        const ret3 = new Array(fixedLength);
+        const ret3 = [];
         for (let j = 0; j < fixedLength; j++) {
-          ret3[j] = String.fromCodePoint(ret1[j]);
+          if (ret1[j] === 0) break; // null terminates the string, matching NumPy behavior
+          ret3.push(String.fromCodePoint(ret1[j]));
         }
         ret2.push(ret3.join(""));
       }
@@ -109,7 +110,15 @@ const zarrDecodeChunkArray = async (
       const ret2 = [];
       for (let i = 0; i < nn; i++) {
         const ret1 = new Uint8Array(ret, i * fixedLength, fixedLength);
-        ret2.push(new TextDecoder().decode(ret1));
+        // Find first null byte to trim, matching NumPy behavior
+        let len = fixedLength;
+        for (let j = 0; j < fixedLength; j++) {
+          if (ret1[j] === 0) {
+            len = j;
+            break;
+          }
+        }
+        ret2.push(new TextDecoder().decode(ret1.subarray(0, len)));
       }
       ret = ret2;
     } else {


### PR DESCRIPTION
## Summary
- Strip null characters when decoding fixed-width NumPy strings (`<U` and `|S` dtypes) in zarr chunks, matching NumPy's null-termination behavior. Previously, null bytes were converted to literal `\^@` characters that browsers rendered as the replacement character `�`.
- Fix extra `)` in IndexSeries print statement that generated invalid Python syntax.

## Test plan
- [ ] Open https://neurosift.app/nwb?url=https://api.dandiarchive.org/api/assets/f24e825f-f5b1-4287-a004-7ac3a20c107d/download/&dandisetId=000409&dandisetVersion=0.260309.1324 and verify the Python usage script no longer shows `�`

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)