### PR TITLE
feat: Add PoseEstimationSkeletonPlugin for skeleton visualization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4795,9 +4795,10 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
     },
     "node_modules/d": {
       "version": "1.0.2",
@@ -10239,6 +10240,17 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/pubnub/node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/pubnub/node_modules/ansi-regex": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@mui/material": "^6.4.2",
         "@types/plotly.js": "^2.35.2",
         "@types/react-syntax-highlighter": "^15.5.13",
-        "@vercel/analytics": "^1.4.1",
         "mathjs": "^14.2.1",
         "nifti-reader-js": "^0.7.0",
         "numcodecs": "^0.3.1",
@@ -3411,43 +3410,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
-    },
-    "node_modules/@vercel/analytics": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.5.0.tgz",
-      "integrity": "sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==",
-      "peerDependencies": {
-        "@remix-run/react": "^2",
-        "@sveltejs/kit": "^1 || ^2",
-        "next": ">= 13",
-        "react": "^18 || ^19 || ^19.0.0-rc",
-        "svelte": ">= 4",
-        "vue": "^3",
-        "vue-router": "^4"
-      },
-      "peerDependenciesMeta": {
-        "@remix-run/react": {
-          "optional": true
-        },
-        "@sveltejs/kit": {
-          "optional": true
-        },
-        "next": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "svelte": {
-          "optional": true
-        },
-        "vue": {
-          "optional": true
-        },
-        "vue-router": {
-          "optional": true
-        }
-      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.3.4",
@@ -10279,16 +10241,6 @@
         }
       }
     },
-    "node_modules/pubnub/node_modules/@types/react": {
-      "version": "19.1.8",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
-      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "csstype": "^3.0.2"
-      }
-    },
     "node_modules/pubnub/node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -12933,20 +12885,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
-    },
-    "node_modules/yaml": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/src/pages/NwbPage/plugins/PoseEstimationSkeleton/PoseEstimationSkeletonView.tsx
+++ b/src/pages/NwbPage/plugins/PoseEstimationSkeleton/PoseEstimationSkeletonView.tsx
@@ -1,0 +1,162 @@
+import { FunctionComponent, useState, useEffect } from "react";
+import { useTimeseriesSelection } from "@shared/context-timeseries-selection-2";
+import TimeseriesSelectionBarWithControls from "@shared/TimeseriesSelectionBar/TimeseriesSelectionBarWithControls";
+import { usePoseData } from "./hooks/usePoseData";
+import { useSkeletonDefinition } from "./hooks/useSkeletonDefinition";
+import SkeletonPlot from "./SkeletonPlot/SkeletonPlot";
+
+type Props = {
+  nwbUrl: string;
+  path: string;
+  width?: number;
+  height?: number;
+  condensed?: boolean;
+};
+
+const timeSelectionBarHeight = 24;
+
+const PoseEstimationSkeletonView: FunctionComponent<Props> = ({
+  nwbUrl,
+  path,
+  width = 800,
+  height = 600,
+}) => {
+  const [showConfidence, setShowConfidence] = useState(true);
+  const [showTrajectories, setShowTrajectories] = useState(false);
+  const [confidenceThreshold, setConfidenceThreshold] = useState(0.0);
+  
+  const { currentTime, visibleStartTimeSec, visibleEndTimeSec, initializeTimeseriesSelection } 
+    = useTimeseriesSelection();
+  
+  // Load skeleton structure (nodes and edges)
+  const { skeleton, skeletonError } = useSkeletonDefinition(nwbUrl, path);
+  
+  // Load pose data for all body parts
+  const { 
+    poseData,      // Map<bodyPartName, { x, y, confidence, timestamps }>
+    timeRange,     // { startTime, endTime }
+    isLoading, 
+    error 
+  } = usePoseData(nwbUrl, path, skeleton);
+  
+  // Initialize time selection context
+  useEffect(() => {
+    if (!timeRange) return;
+    initializeTimeseriesSelection({
+      startTimeSec: timeRange.startTime,
+      endTimeSec: timeRange.endTime,
+      initialVisibleStartTimeSec: timeRange.startTime,
+      initialVisibleEndTimeSec: Math.min(
+        timeRange.startTime + 10, // Show first 10 seconds
+        timeRange.endTime
+      ),
+    });
+  }, [timeRange, initializeTimeseriesSelection]);
+  
+  const plotHeight = height - timeSelectionBarHeight;
+  
+  if (error || skeletonError) {
+    return <div style={{ color: "red" }}>Error: {error || skeletonError}</div>;
+  }
+  
+  if (!skeleton || !poseData) {
+    return <div>Loading pose estimation data...</div>;
+  }
+  
+  return (
+    <div style={{ position: "relative", width, height }}>
+      {/* Time Selection Bar */}
+      <div style={{ position: "absolute", width, height: timeSelectionBarHeight }}>
+        <TimeseriesSelectionBarWithControls
+          width={width}
+          height={timeSelectionBarHeight}
+        />
+      </div>
+      
+      {/* Controls */}
+      <div style={{ 
+        position: "absolute", 
+        top: timeSelectionBarHeight + 5, 
+        right: 10,
+        zIndex: 100,
+        display: "flex",
+        gap: "8px",
+        flexDirection: "column",
+        alignItems: "flex-end",
+        backgroundColor: "rgba(255, 255, 255, 0.9)",
+        padding: "8px",
+        borderRadius: "4px",
+        boxShadow: "0 2px 4px rgba(0,0,0,0.1)"
+      }}>
+        <label style={{ display: "flex", alignItems: "center", gap: "4px", cursor: "pointer" }}>
+          <input
+            type="checkbox"
+            checked={showConfidence}
+            onChange={(e) => setShowConfidence(e.target.checked)}
+          />
+          <span style={{ fontSize: "12px" }}>Show Confidence</span>
+        </label>
+        
+        <label style={{ display: "flex", alignItems: "center", gap: "4px", cursor: "pointer" }}>
+          <input
+            type="checkbox"
+            checked={showTrajectories}
+            onChange={(e) => setShowTrajectories(e.target.checked)}
+          />
+          <span style={{ fontSize: "12px" }}>Show Trajectories</span>
+        </label>
+        
+        {showConfidence && (
+          <div style={{ display: "flex", flexDirection: "column", gap: "4px", minWidth: "180px" }}>
+            <label style={{ fontSize: "12px" }}>
+              Threshold: {confidenceThreshold.toFixed(2)}
+            </label>
+            <input
+              type="range"
+              min="0"
+              max="1"
+              step="0.05"
+              value={confidenceThreshold}
+              onChange={(e) => setConfidenceThreshold(parseFloat(e.target.value))}
+              style={{ width: "100%" }}
+            />
+          </div>
+        )}
+      </div>
+      
+      {/* Main Plot Area */}
+      <div style={{
+        position: "absolute",
+        top: timeSelectionBarHeight,
+        width,
+        height: plotHeight,
+      }}>
+        <SkeletonPlot
+          width={width}
+          height={plotHeight}
+          skeleton={skeleton}
+          poseData={poseData}
+          currentTime={currentTime}
+          visibleStartTime={visibleStartTimeSec}
+          visibleEndTime={visibleEndTimeSec}
+          showConfidence={showConfidence}
+          showTrajectories={showTrajectories}
+          confidenceThreshold={confidenceThreshold}
+        />
+      </div>
+      
+      {isLoading && (
+        <div style={{
+          position: "absolute",
+          top: timeSelectionBarHeight + 20,
+          left: 60,
+          userSelect: "none",
+        }}>
+          <div style={{ fontSize: 20, color: "gray" }}>Loading...</div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PoseEstimationSkeletonView;

--- a/src/pages/NwbPage/plugins/PoseEstimationSkeleton/SkeletonPlot/SkeletonPlot.tsx
+++ b/src/pages/NwbPage/plugins/PoseEstimationSkeleton/SkeletonPlot/SkeletonPlot.tsx
@@ -1,0 +1,292 @@
+import { FunctionComponent, useMemo } from "react";
+import Plot from "react-plotly.js";
+import { Layout, PlotData } from "plotly.js";
+import { SkeletonPlotProps } from "./types";
+import { findClosestFrameIndex } from "../utils/confidenceUtils";
+
+const SkeletonPlot: FunctionComponent<SkeletonPlotProps> = ({
+  width,
+  height,
+  skeleton,
+  poseData,
+  currentTime,
+  visibleStartTime,
+  visibleEndTime,
+  showConfidence,
+  showTrajectories,
+  confidenceThreshold,
+}) => {
+  
+  // Find frame index for current time
+  const currentFrameIndex = useMemo(() => {
+    if (currentTime === undefined) return -1;
+    
+    // Use first body part's timestamps as reference
+    const firstBodyPart = skeleton.nodes[0];
+    const firstData = poseData.get(firstBodyPart);
+    if (!firstData) return -1;
+    
+    return findClosestFrameIndex(firstData.timestamps, currentTime);
+  }, [currentTime, skeleton, poseData]);
+  
+  // Extract keypoint positions for current frame
+  const currentKeypoints = useMemo(() => {
+    if (currentFrameIndex < 0) return null;
+    
+    const keypoints = new Map<string, { x: number; y: number; confidence: number }>();
+    
+    skeleton.nodes.forEach(bodyPartName => {
+      const data = poseData.get(bodyPartName);
+      if (!data || currentFrameIndex >= data.x.length) return;
+      
+      const x = data.x[currentFrameIndex];
+      const y = data.y[currentFrameIndex];
+      const confidence = data.confidence[currentFrameIndex];
+      
+      keypoints.set(bodyPartName, { x, y, confidence });
+    });
+    
+    return keypoints;
+  }, [currentFrameIndex, skeleton, poseData]);
+  
+  // Calculate spatial bounds across all data
+  const bounds = useMemo(() => {
+    let xMin = Infinity, xMax = -Infinity;
+    let yMin = Infinity, yMax = -Infinity;
+    
+    poseData.forEach(data => {
+      data.x.forEach(x => {
+        if (x < xMin) xMin = x;
+        if (x > xMax) xMax = x;
+      });
+      data.y.forEach(y => {
+        if (y < yMin) yMin = y;
+        if (y > yMax) yMax = y;
+      });
+    });
+    
+    // Add 10% padding
+    const xPadding = (xMax - xMin) * 0.1 || 10;
+    const yPadding = (yMax - yMin) * 0.1 || 10;
+    
+    return {
+      xMin: xMin - xPadding,
+      xMax: xMax + xPadding,
+      yMin: yMin - yPadding,
+      yMax: yMax + yPadding,
+    };
+  }, [poseData]);
+  
+  // Generate Plotly traces
+  const traces: Partial<PlotData>[] = useMemo(() => {
+    const traces: Partial<PlotData>[] = [];
+    
+    if (!currentKeypoints) return traces;
+    
+    // 1. Draw skeleton edges (bones)
+    skeleton.edges.forEach(([idx1, idx2], edgeIdx) => {
+      const bodyPart1 = skeleton.nodes[idx1];
+      const bodyPart2 = skeleton.nodes[idx2];
+      
+      const kp1 = currentKeypoints.get(bodyPart1);
+      const kp2 = currentKeypoints.get(bodyPart2);
+      
+      if (!kp1 || !kp2) return;
+      
+      // Filter by confidence threshold
+      if (showConfidence) {
+        if (kp1.confidence < confidenceThreshold || kp2.confidence < confidenceThreshold) {
+          return;
+        }
+      }
+      
+      // Edge opacity based on average confidence
+      const avgConfidence = (kp1.confidence + kp2.confidence) / 2;
+      const opacity = showConfidence ? avgConfidence : 1.0;
+      
+      traces.push({
+        type: "scatter",
+        mode: "lines",
+        x: [kp1.x, kp2.x],
+        y: [kp1.y, kp2.y],
+        line: {
+          color: `rgba(46, 139, 87, ${opacity})`,  // SeaGreen with confidence opacity
+          width: 3,
+        },
+        showlegend: false,
+        hoverinfo: "skip",
+        name: `edge_${edgeIdx}`,
+      });
+    });
+    
+    // 2. Draw keypoints (joints)
+    const keypointX: number[] = [];
+    const keypointY: number[] = [];
+    const keypointColors: number[] = [];
+    const keypointText: string[] = [];
+    const keypointSizes: number[] = [];
+    
+    skeleton.nodes.forEach(bodyPartName => {
+      const kp = currentKeypoints.get(bodyPartName);
+      if (!kp) return;
+      
+      // Filter by confidence threshold
+      if (showConfidence && kp.confidence < confidenceThreshold) {
+        return;
+      }
+      
+      keypointX.push(kp.x);
+      keypointY.push(kp.y);
+      keypointColors.push(kp.confidence);
+      keypointText.push(
+        `${bodyPartName}<br>` +
+        `x: ${kp.x.toFixed(2)}<br>` +
+        `y: ${kp.y.toFixed(2)}<br>` +
+        `confidence: ${kp.confidence.toFixed(3)}`
+      );
+      keypointSizes.push(showConfidence ? 8 + kp.confidence * 4 : 10);
+    });
+    
+    if (keypointX.length > 0) {
+      traces.push({
+        type: "scatter",
+        mode: "markers",
+        x: keypointX,
+        y: keypointY,
+        marker: {
+          size: keypointSizes,
+          color: showConfidence ? keypointColors : "#FF6B35",
+          colorscale: showConfidence ? "RdYlGn" : undefined,  // Red (low) to Green (high)
+          cmin: 0,
+          cmax: 1,
+          showscale: showConfidence,
+          colorbar: showConfidence ? {
+            title: "Confidence",
+            x: 1.02,
+            len: 0.7,
+          } : undefined,
+          line: {
+            color: "white",
+            width: 1,
+          },
+        },
+        text: keypointText,
+        hoverinfo: "text",
+        showlegend: false,
+        name: "keypoints",
+      });
+    }
+    
+    // 3. Draw trajectories (if enabled)
+    if (showTrajectories && visibleStartTime !== undefined && visibleEndTime !== undefined) {
+      skeleton.nodes.forEach(bodyPartName => {
+        const data = poseData.get(bodyPartName);
+        if (!data) return;
+        
+        // Filter to visible time range
+        const visibleIndices = data.timestamps
+          .map((t, idx) => (t >= visibleStartTime && t <= visibleEndTime) ? idx : -1)
+          .filter(idx => idx >= 0);
+        
+        if (visibleIndices.length === 0) return;
+        
+        const trajX = visibleIndices.map(idx => data.x[idx]);
+        const trajY = visibleIndices.map(idx => data.y[idx]);
+        
+        traces.push({
+          type: "scatter",
+          mode: "lines",
+          x: trajX,
+          y: trajY,
+          line: {
+            color: "rgba(100, 100, 100, 0.3)",
+            width: 1,
+          },
+          showlegend: false,
+          hoverinfo: "skip",
+          name: `trajectory_${bodyPartName}`,
+        });
+      });
+    }
+    
+    return traces;
+  }, [
+    skeleton,
+    currentKeypoints,
+    showConfidence,
+    showTrajectories,
+    confidenceThreshold,
+    visibleStartTime,
+    visibleEndTime,
+    poseData,
+  ]);
+  
+  const layout: Partial<Layout> = useMemo(
+    () => ({
+      width,
+      height,
+      margin: {
+        l: 60,
+        r: showConfidence ? 100 : 60,  // Extra space for colorbar
+        t: 20,
+        b: 60,
+        pad: 0,
+      },
+      showlegend: false,
+      xaxis: {
+        title: "X (pixels)",
+        range: [bounds.xMin, bounds.xMax],
+        showgrid: true,
+        zeroline: false,
+      },
+      yaxis: {
+        title: "Y (pixels)",
+        range: [bounds.yMax, bounds.yMin],  // Flip Y axis (image coordinates)
+        scaleanchor: "x",
+        scaleratio: 1,
+        showgrid: true,
+        zeroline: false,
+      },
+      hovermode: "closest",
+      plot_bgcolor: "#f8f9fa",
+      paper_bgcolor: "#ffffff",
+    }),
+    [bounds, width, height, showConfidence],
+  );
+  
+  if (!currentKeypoints) {
+    return (
+      <div style={{ 
+        width, 
+        height, 
+        display: "flex", 
+        alignItems: "center", 
+        justifyContent: "center",
+        backgroundColor: "#f8f9fa"
+      }}>
+        <div style={{ color: "#6c757d" }}>
+          Select a time point to view skeleton
+        </div>
+      </div>
+    );
+  }
+  
+  return (
+    <Plot
+      data={traces}
+      layout={layout}
+      config={{
+        displayModeBar: true,
+        displaylogo: false,
+        modeBarButtonsToRemove: ["lasso2d", "select2d"],
+        responsive: true,
+      }}
+      style={{
+        width: "100%",
+        height: "100%",
+      }}
+    />
+  );
+};
+
+export default SkeletonPlot;

--- a/src/pages/NwbPage/plugins/PoseEstimationSkeleton/SkeletonPlot/types.ts
+++ b/src/pages/NwbPage/plugins/PoseEstimationSkeleton/SkeletonPlot/types.ts
@@ -1,0 +1,30 @@
+export interface Skeleton {
+  name: string;
+  nodes: string[];          // Body part names
+  edges: number[][];        // [nodeIdx1, nodeIdx2] pairs
+}
+
+export interface PoseData {
+  x: number[];
+  y: number[];
+  confidence: number[];
+  timestamps: number[];
+}
+
+export interface TimeRange {
+  startTime: number;
+  endTime: number;
+}
+
+export interface SkeletonPlotProps {
+  width: number;
+  height: number;
+  skeleton: Skeleton;
+  poseData: Map<string, PoseData>;
+  currentTime: number | undefined;
+  visibleStartTime: number | undefined;
+  visibleEndTime: number | undefined;
+  showConfidence: boolean;
+  showTrajectories: boolean;
+  confidenceThreshold: number;
+}

--- a/src/pages/NwbPage/plugins/PoseEstimationSkeleton/hooks/usePoseData.ts
+++ b/src/pages/NwbPage/plugins/PoseEstimationSkeleton/hooks/usePoseData.ts
@@ -1,0 +1,121 @@
+import { useState, useEffect } from "react";
+import { getHdf5Group, getHdf5DatasetData } from "@hdf5Interface";
+import { Skeleton, PoseData, TimeRange } from "../SkeletonPlot/types";
+
+export const usePoseData = (
+  nwbUrl: string,
+  path: string,
+  skeleton: Skeleton | undefined
+) => {
+  const [poseData, setPoseData] = useState<Map<string, PoseData> | undefined>();
+  const [timeRange, setTimeRange] = useState<TimeRange | undefined>();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+
+  useEffect(() => {
+    if (!skeleton) return;
+    
+    let canceled = false;
+    setIsLoading(true);
+    
+    const loadPoseData = async () => {
+      try {
+        const group = await getHdf5Group(nwbUrl, path);
+        if (!group || canceled) return;
+        
+        const poseSeriesGroups = group.subgroups.filter(
+          (g: any) => g.attrs?.neurodata_type === "PoseEstimationSeries"
+        );
+        
+        const dataMap = new Map<string, PoseData>();
+        let globalStartTime = Infinity;
+        let globalEndTime = -Infinity;
+        
+        for (const bodyPartName of skeleton.nodes) {
+          // Find matching PoseEstimationSeries
+          const seriesGroup = poseSeriesGroups.find(
+            (g: any) => g.name === bodyPartName
+          );
+          
+          if (!seriesGroup) {
+            console.warn(`No PoseEstimationSeries found for body part: ${bodyPartName}`);
+            continue;
+          }
+          
+          const seriesPath = `${path}/${bodyPartName}`;
+          
+          // Load data, timestamps, and confidence
+          const data = await getHdf5DatasetData(nwbUrl, `${seriesPath}/data`, {});
+          const timestamps = await getHdf5DatasetData(nwbUrl, `${seriesPath}/timestamps`, {});
+          
+          if (!data || !timestamps || canceled) continue;
+          
+          // Try to load confidence, if it doesn't exist, default to 1.0
+          let confidence;
+          try {
+            confidence = await getHdf5DatasetData(nwbUrl, `${seriesPath}/confidence`, {});
+          } catch {
+            confidence = new Array(timestamps.length).fill(1.0);
+          }
+          
+          if (!confidence) {
+            confidence = new Array(timestamps.length).fill(1.0);
+          }
+          
+          // Extract x and y coordinates
+          const x: number[] = [];
+          const y: number[] = [];
+          
+          // Convert data to array if needed
+          const dataArray = Array.isArray(data) ? data : Array.from(data as any);
+          
+          for (let i = 0; i < dataArray.length; i++) {
+            if (Array.isArray(dataArray[i])) {
+              x.push(Number(dataArray[i][0]));
+              y.push(Number(dataArray[i][1]));
+            } else {
+              // Handle flat array format
+              x.push(Number(dataArray[i * 2]) || 0);
+              y.push(Number(dataArray[i * 2 + 1]) || 0);
+            }
+          }
+          
+          dataMap.set(bodyPartName, {
+            x,
+            y,
+            confidence: Array.from(confidence),
+            timestamps: Array.from(timestamps),
+          });
+          
+          // Update global time range
+          if (timestamps.length > 0) {
+            globalStartTime = Math.min(globalStartTime, timestamps[0]);
+            globalEndTime = Math.max(globalEndTime, timestamps[timestamps.length - 1]);
+          }
+        }
+        
+        if (canceled) return;
+        
+        setPoseData(dataMap);
+        setTimeRange({
+          startTime: globalStartTime,
+          endTime: globalEndTime,
+        });
+        setIsLoading(false);
+      } catch (err) {
+        if (!canceled) {
+          setError(err instanceof Error ? err.message : String(err));
+          setIsLoading(false);
+        }
+      }
+    };
+    
+    loadPoseData();
+    
+    return () => {
+      canceled = true;
+    };
+  }, [nwbUrl, path, skeleton]);
+  
+  return { poseData, timeRange, isLoading, error };
+};

--- a/src/pages/NwbPage/plugins/PoseEstimationSkeleton/hooks/useSkeletonDefinition.ts
+++ b/src/pages/NwbPage/plugins/PoseEstimationSkeleton/hooks/useSkeletonDefinition.ts
@@ -1,0 +1,99 @@
+import { useState, useEffect } from "react";
+import { getHdf5Group, getHdf5DatasetData } from "@hdf5Interface";
+import { Skeleton } from "../SkeletonPlot/types";
+
+export const useSkeletonDefinition = (nwbUrl: string, path: string) => {
+  const [skeleton, setSkeleton] = useState<Skeleton | undefined>();
+  const [error, setError] = useState<string | undefined>();
+
+  useEffect(() => {
+    let canceled = false;
+    
+    const loadSkeleton = async () => {
+      try {
+        const poseEstimationGroup = await getHdf5Group(nwbUrl, path);
+        if (!poseEstimationGroup || canceled) return;
+        
+        // Find skeleton reference in attributes
+        const skeletonAttr = poseEstimationGroup.attrs?.skeleton;
+        
+        if (!skeletonAttr) {
+          // If no skeleton reference, try to infer from pose estimation series
+          const poseSeriesGroups = poseEstimationGroup.subgroups.filter(
+            (g: any) => g.attrs?.neurodata_type === "PoseEstimationSeries"
+          );
+          
+          if (poseSeriesGroups.length > 0) {
+            // Create a simple skeleton with just nodes (no edges)
+            const nodes = poseSeriesGroups.map((g: any) => g.name);
+            setSkeleton({
+              name: "inferred_skeleton",
+              nodes,
+              edges: [],
+            });
+          } else {
+            setError("No skeleton reference or pose series found");
+          }
+          return;
+        }
+        
+        // Handle skeleton reference (could be a link object or path string)
+        let skeletonPath: string;
+        if (typeof skeletonAttr === "string") {
+          skeletonPath = skeletonAttr;
+        } else if (skeletonAttr.path) {
+          skeletonPath = skeletonAttr.path;
+        } else {
+          setError("Invalid skeleton reference");
+          return;
+        }
+        
+        const skeletonGroup = await getHdf5Group(nwbUrl, skeletonPath);
+        if (!skeletonGroup || canceled) return;
+        
+        // Read nodes (array of strings - body part names)
+        const nodesRaw = await getHdf5DatasetData(nwbUrl, `${skeletonPath}/nodes`, {}) || [];
+        const nodes = Array.from(nodesRaw as any).map((n: any) => String(n));
+        
+        // Read edges (array of [nodeIndex1, nodeIndex2] pairs)
+        const edgesRaw = await getHdf5DatasetData(nwbUrl, `${skeletonPath}/edges`, {}) || [];
+        
+        // Convert edges to array of pairs
+        const edges: number[][] = [];
+        if (edgesRaw && (edgesRaw as any).length > 0) {
+          const edgesArray = Array.from(edgesRaw as any);
+          for (let i = 0; i < edgesArray.length; i++) {
+            const edge = edgesArray[i];
+            if (Array.isArray(edge)) {
+              edges.push([Number((edge as any)[0]), Number((edge as any)[1])]);
+            } else if (i + 1 < edgesArray.length) {
+              // Flat array format: [idx1, idx2, idx3, idx4, ...]
+              edges.push([Number(edge), Number(edgesArray[i + 1])]);
+              i++;
+            }
+          }
+        }
+        
+        if (canceled) return;
+        
+        setSkeleton({
+          name: skeletonGroup.attrs?.name || "skeleton",
+          nodes,
+          edges,
+        });
+      } catch (err) {
+        if (!canceled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      }
+    };
+    
+    loadSkeleton();
+    
+    return () => {
+      canceled = true;
+    };
+  }, [nwbUrl, path]);
+  
+  return { skeleton, skeletonError: error };
+};

--- a/src/pages/NwbPage/plugins/PoseEstimationSkeleton/index.ts
+++ b/src/pages/NwbPage/plugins/PoseEstimationSkeleton/index.ts
@@ -1,0 +1,27 @@
+import { getHdf5Group } from "@hdf5Interface";
+import { NwbObjectViewPlugin } from "../pluginInterface";
+import PoseEstimationSkeletonView from "./PoseEstimationSkeletonView";
+
+export const poseEstimationSkeletonPlugin: NwbObjectViewPlugin = {
+  name: "PoseEstimationSkeleton",
+  label: "Skeleton Plot",
+  canHandle: async ({ nwbUrl, path }) => {
+    const group = await getHdf5Group(nwbUrl, path);
+    if (!group) return false;
+    
+    // Handle PoseEstimation containers
+    if (group.attrs["neurodata_type"] === "PoseEstimation") {
+      // Verify it has pose estimation series
+      const hasPoseSeries = group.subgroups.some(
+        (g: any) => g.attrs?.neurodata_type === "PoseEstimationSeries"
+      );
+      return hasPoseSeries;
+    }
+    
+    return false;
+  },
+  component: PoseEstimationSkeletonView,
+  requiresWindowDimensions: true,
+  showInMultiView: true,  // Important for multi-view layouts
+  launchableFromTable: false,
+};

--- a/src/pages/NwbPage/plugins/PoseEstimationSkeleton/utils/confidenceUtils.ts
+++ b/src/pages/NwbPage/plugins/PoseEstimationSkeleton/utils/confidenceUtils.ts
@@ -1,0 +1,49 @@
+export const findClosestFrameIndex = (
+  timestamps: number[],
+  targetTime: number
+): number => {
+  let closestIndex = 0;
+  let minDiff = Math.abs(timestamps[0] - targetTime);
+  
+  for (let i = 1; i < timestamps.length; i++) {
+    const diff = Math.abs(timestamps[i] - targetTime);
+    if (diff < minDiff) {
+      minDiff = diff;
+      closestIndex = i;
+    }
+  }
+  
+  return closestIndex;
+};
+
+export const applyConfidenceThreshold = (
+  confidence: number,
+  threshold: number
+): boolean => {
+  return confidence >= threshold;
+};
+
+export const confidenceToOpacity = (
+  confidence: number,
+  minOpacity: number = 0.3,
+  maxOpacity: number = 1.0
+): number => {
+  return minOpacity + (maxOpacity - minOpacity) * confidence;
+};
+
+export const confidenceToColor = (
+  confidence: number
+): string => {
+  // Red (0) -> Yellow (0.5) -> Green (1.0)
+  if (confidence < 0.5) {
+    const t = confidence * 2;
+    const r = 255;
+    const g = Math.round(255 * t);
+    return `rgb(${r}, ${g}, 0)`;
+  } else {
+    const t = (confidence - 0.5) * 2;
+    const r = Math.round(255 * (1 - t));
+    const g = 255;
+    return `rgb(${r}, ${g}, 0)`;
+  }
+};

--- a/src/pages/NwbPage/plugins/registry.ts
+++ b/src/pages/NwbPage/plugins/registry.ts
@@ -25,6 +25,7 @@ import {
   figpackVideoPreviewPlugin,
   figpackRasterPlotPlugin,
 } from "./Figpack";
+import { poseEstimationSkeletonPlugin } from "./PoseEstimationSkeleton";
 
 // List of plugins in order they will appear in the UI when a single object is being viewed
 export const nwbObjectViewPlugins: NwbObjectViewPlugin[] = [
@@ -47,6 +48,9 @@ export const nwbObjectViewPlugins: NwbObjectViewPlugin[] = [
 
   rasterPlugin,
   // spikeDensityPlugin,
+
+  // PoseEstimation skeleton visualization (insert before Figpack)
+  poseEstimationSkeletonPlugin,
 
   figpackRasterPlotPlugin,
   figpackVideoPreviewPlugin,


### PR DESCRIPTION
- Implements Phase 1 (MVP) of pose estimation visualization
- Skeleton rendering with Plotly
- Keypoint visualization with confidence (color/opacity/size)
- Time synchronization with existing system
- Basic playback controls via TimeseriesSelectionBar
- Supports confidence threshold filtering
- Optional trajectory visualization
- Plugin registered before Figpack to take precedence

Features:
- Renders full skeleton from PoseEstimation containers
- Visualizes confidence using RdYlGn colorscale
- Interactive controls for confidence display
- Integrated with multi-view layouts
- Handles missing skeleton references gracefully