### PR TITLE
Redesign PSTH left panel with accordion layout

### DIFF
--- a/src/pages/NwbPage/plugins/PSTH/PSTHItemView/PSTHItemView.tsx
+++ b/src/pages/NwbPage/plugins/PSTH/PSTHItemView/PSTHItemView.tsx
@@ -214,11 +214,17 @@ const PSTHItemViewChild: FunctionComponent<PSTHItemViewChildProps> = ({
     }
   }, [mode, prefsDispatch]);
 
+  // Track whether we've already restored non-unit state from the initial state string
+  const [initialStateRestored, setInitialStateRestored] = useState(false);
+  const [pendingSelectAll, setPendingSelectAll] = useState(false);
+
   useEffect(() => {
-    if (!initialStateString) return;
+    if (!initialStateString || initialStateRestored) return;
     const a = decodeStateFromStateString(initialStateString);
     if (!a) return;
-    if (a.selectedUnitIds) {
+    if (a.selectedUnitIds === "__all__") {
+      setPendingSelectAll(true);
+    } else if (a.selectedUnitIds && Array.isArray(a.selectedUnitIds)) {
       const sortedSelectedUnitIds = [...a.selectedUnitIds].sort();
       setSelectedUnitIds(sortedSelectedUnitIds);
     }
@@ -266,12 +272,33 @@ const PSTHItemViewChild: FunctionComponent<PSTHItemViewChildProps> = ({
         value: a.prefs.numBins,
       });
     }
-  }, [initialStateString, setSelectedUnitIds, prefsDispatch]);
+    setInitialStateRestored(true);
+  }, [initialStateString, initialStateRestored, setSelectedUnitIds, prefsDispatch]);
+
+  // Handle "select all" once unit IDs are loaded
+  useEffect(() => {
+    if (pendingSelectAll && unitIds) {
+      setSelectedUnitIds([...unitIds]);
+      setPendingSelectAll(false);
+    }
+  }, [pendingSelectAll, unitIds, setSelectedUnitIds]);
 
   useEffect(() => {
     if (!setStateString) return;
+    // Encode unit selection compactly:
+    // - "__all__" if all units are selected
+    // - the list if <=10 are selected
+    // - undefined otherwise (too many to store in URL)
+    let encodedUnitIds: (number | string)[] | "__all__" | undefined;
+    if (unitIds && selectedUnitIds.length === unitIds.length && unitIds.length > 0) {
+      encodedUnitIds = "__all__";
+    } else if (selectedUnitIds.length <= 10) {
+      encodedUnitIds = selectedUnitIds;
+    } else {
+      encodedUnitIds = undefined;
+    }
     const state0 = {
-      selectedUnitIds,
+      selectedUnitIds: encodedUnitIds,
       selectedRoiIndices,
       alignToVariables,
       groupByVariable,
@@ -293,6 +320,7 @@ const PSTHItemViewChild: FunctionComponent<PSTHItemViewChildProps> = ({
     sortUnitsByVariable,
     windowRangeStr,
     prefs,
+    unitIds,
   ]);
 
   const rawTrialIndices = useTrialsFilterIndices(trialsFilter, nwbUrl, path);

--- a/src/pages/NwbPage/plugins/PSTH/PSTHItemView/PSTHUnitWidget.tsx
+++ b/src/pages/NwbPage/plugins/PSTH/PSTHItemView/PSTHUnitWidget.tsx
@@ -117,8 +117,10 @@ const PSTHUnitWidget: FunctionComponent<Props> = ({
           position: "absolute",
           width,
           height: topBarHeight,
-          fontSize: 24,
-          marginLeft: 30,
+          fontSize: 16,
+          fontWeight: "bold",
+          marginLeft: 5,
+          marginTop: 2,
         }}
       >
         Unit {unitId}

--- a/src/pages/NwbPage/plugins/PSTH/PSTHItemView/components/AlignToSelection.tsx
+++ b/src/pages/NwbPage/plugins/PSTH/PSTHItemView/components/AlignToSelection.tsx
@@ -20,17 +20,14 @@ const AlignToSelectionComponent: FunctionComponent<AlignToSelectionProps> = ({
     .filter((name) => name.endsWith("_time") || name.endsWith("_times"));
 
   return (
-    <table className="nwb-table">
-      <thead>
-        <tr>
-          <th></th>
-          <th>Align to</th>
-        </tr>
-      </thead>
+    <table className="nwb-table" style={{ tableLayout: "fixed" }}>
+      <colgroup>
+        <col style={{ width: 20 }} />
+      </colgroup>
       <tbody>
         {options.map((option) => (
           <tr key={option}>
-            <td>
+            <td style={{ padding: "4px 2px" }}>
               <input
                 type="checkbox"
                 checked={alignToVariables.includes(option)}

--- a/src/pages/NwbPage/plugins/PSTH/PSTHItemView/components/GroupByCategories.tsx
+++ b/src/pages/NwbPage/plugins/PSTH/PSTHItemView/components/GroupByCategories.tsx
@@ -1,0 +1,77 @@
+import { FunctionComponent } from "react";
+
+type Props = {
+  groupByVariableCategories: string[] | undefined;
+  setGroupByVariableCategories: (x: string[] | undefined) => void;
+  options: string[];
+};
+
+const GroupByCategoriesComponent: FunctionComponent<Props> = ({
+  groupByVariableCategories,
+  setGroupByVariableCategories,
+  options,
+}) => {
+  const allSelected = !groupByVariableCategories || groupByVariableCategories.length === options.length;
+
+  return (
+    <table className="nwb-table" style={{ tableLayout: "fixed" }}>
+      <colgroup>
+        <col style={{ width: 20 }} />
+      </colgroup>
+      <tbody>
+        <tr>
+          <td style={{ padding: "4px 2px" }}>
+            <input
+              type="checkbox"
+              checked={allSelected}
+              onChange={() => {}}
+              onClick={() => {
+                if (allSelected) {
+                  setGroupByVariableCategories([]);
+                } else {
+                  setGroupByVariableCategories(undefined);
+                }
+              }}
+            />
+          </td>
+          <td style={{ fontStyle: "italic" }}>All</td>
+        </tr>
+        {options.map((option) => (
+          <tr key={option}>
+            <td style={{ padding: "4px 2px" }}>
+              <input
+                type="checkbox"
+                checked={
+                  groupByVariableCategories?.includes(option) ||
+                  !groupByVariableCategories
+                }
+                onChange={() => {}}
+                onClick={() => {
+                  if (groupByVariableCategories) {
+                    if (groupByVariableCategories.includes(option)) {
+                      setGroupByVariableCategories(
+                        groupByVariableCategories.filter((x) => x !== option),
+                      );
+                    } else {
+                      setGroupByVariableCategories([
+                        ...groupByVariableCategories,
+                        option,
+                      ]);
+                    }
+                  } else {
+                    setGroupByVariableCategories(
+                      options.filter((x) => x !== option),
+                    );
+                  }
+                }}
+              />
+            </td>
+            <td>{option}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+export default GroupByCategoriesComponent;

--- a/src/pages/NwbPage/plugins/PSTH/PSTHItemView/components/GroupBySelection.tsx
+++ b/src/pages/NwbPage/plugins/PSTH/PSTHItemView/components/GroupBySelection.tsx
@@ -1,18 +1,11 @@
-import { FunctionComponent, useMemo, useEffect, useState } from "react";
-import { useHdf5Group, getHdf5DatasetData } from "@hdf5Interface";
+import { FunctionComponent } from "react";
+import { useCategoricalOptions } from "../hooks/useGroupByCategories";
 
 type GroupBySelectionProps = {
   groupByVariable: string;
   setGroupByVariable: (x: string) => void;
   nwbUrl: string;
   path: string;
-  groupByVariableCategories?: string[];
-  setGroupByVariableCategories?: (x: string[] | undefined) => void;
-};
-
-type CategoricalOption = {
-  variableName: string;
-  categories: string[];
 };
 
 const GroupBySelectionComponent: FunctionComponent<GroupBySelectionProps> = ({
@@ -20,67 +13,8 @@ const GroupBySelectionComponent: FunctionComponent<GroupBySelectionProps> = ({
   setGroupByVariable,
   nwbUrl,
   path,
-  groupByVariableCategories,
-  setGroupByVariableCategories,
 }) => {
-  const group = useHdf5Group(nwbUrl, path);
-  const options = useMemo(
-    () =>
-      (group?.datasets || [])
-        .map((ds) => ds.name)
-        .filter((name) => !name.endsWith("_time") && !name.endsWith("_times")),
-    [group],
-  );
-
-  // determine which columns are categorical -- but don't let this slow down the UI
-  // while it is calculating, we can use the full list of options
-  const [categoricalOptions, setCategoricalOptions] = useState<
-    CategoricalOption[] | undefined
-  >(undefined);
-
-  useEffect(() => {
-    if (!group) return;
-    let canceled = false;
-    const load = async () => {
-      const categoricalOptions: CategoricalOption[] = [];
-      for (const option of options) {
-        const ds = group.datasets.find((ds) => ds.name === option);
-        if (!ds) continue;
-        if (ds.shape.length !== 1) continue;
-        const slice =
-          ds.shape[0] < 10000
-            ? undefined
-            : ([[0, 10000]] as [number, number][]); // just check the first values
-        const dd = await getHdf5DatasetData(nwbUrl, path + "/" + option, {
-          slice,
-        });
-        if (!dd) throw Error(`Unable to get data for ${path}/${option}`);
-        if (canceled) return;
-        const stringValues = [...dd].map((x) => x.toString());
-        const uniqueValues: string[] = [...new Set(stringValues)];
-        if (uniqueValues.length <= dd.length / 2) {
-          categoricalOptions.push({
-            variableName: option,
-            categories: uniqueValues,
-          });
-        }
-      }
-      if (canceled) return;
-      setCategoricalOptions(categoricalOptions);
-    };
-    load();
-    return () => {
-      canceled = true;
-    };
-  }, [options, group, nwbUrl, path]);
-
-  const categoriesForSelectedVariable = useMemo(() => {
-    if (!groupByVariable) return undefined;
-    const opt = categoricalOptions?.find(
-      (opt) => opt.variableName === groupByVariable,
-    );
-    return opt ? opt.categories : undefined;
-  }, [groupByVariable, categoricalOptions]);
+  const categoricalOptions = useCategoricalOptions(nwbUrl, path);
 
   return (
     <>
@@ -99,60 +33,6 @@ const GroupBySelectionComponent: FunctionComponent<GroupBySelectionProps> = ({
           </option>
         ))}
       </select>
-      &nbsp;
-      {categoriesForSelectedVariable && setGroupByVariableCategories && (
-        <GroupByVariableCategoriesComponent
-          groupByVariableCategories={groupByVariableCategories}
-          setGroupByVariableCategories={setGroupByVariableCategories}
-          options={categoriesForSelectedVariable}
-        />
-      )}
-    </>
-  );
-};
-
-type GroupByVariableCategoriesProps = {
-  groupByVariableCategories: string[] | undefined;
-  setGroupByVariableCategories: (x: string[] | undefined) => void;
-  options: string[];
-};
-
-const GroupByVariableCategoriesComponent: FunctionComponent<
-  GroupByVariableCategoriesProps
-> = ({ groupByVariableCategories, setGroupByVariableCategories, options }) => {
-  return (
-    <>
-      {options.map((option) => (
-        <span key={option}>
-          <input
-            type="checkbox"
-            checked={
-              groupByVariableCategories?.includes(option) ||
-              !groupByVariableCategories
-            }
-            onChange={() => {}}
-            onClick={() => {
-              if (groupByVariableCategories) {
-                if (groupByVariableCategories.includes(option)) {
-                  setGroupByVariableCategories(
-                    groupByVariableCategories.filter((x) => x !== option),
-                  );
-                } else {
-                  setGroupByVariableCategories([
-                    ...(groupByVariableCategories || []),
-                    option,
-                  ]);
-                }
-              } else {
-                setGroupByVariableCategories(
-                  options.filter((x) => x !== option),
-                );
-              }
-            }}
-          />
-          {option}
-        </span>
-      ))}
     </>
   );
 };

--- a/src/pages/NwbPage/plugins/PSTH/PSTHItemView/components/PSTHBottomControls.tsx
+++ b/src/pages/NwbPage/plugins/PSTH/PSTHItemView/components/PSTHBottomControls.tsx
@@ -33,7 +33,6 @@ const PSTHBottomControls: FunctionComponent<Props> = ({
   setGroupByVariableCategories,
   nwbUrl,
   path,
-  groupByVariableCategories,
   sortUnitsByVariable,
   setSortUnitsByVariable,
   unitsPath,

--- a/src/pages/NwbPage/plugins/PSTH/PSTHItemView/components/PSTHBottomControls.tsx
+++ b/src/pages/NwbPage/plugins/PSTH/PSTHItemView/components/PSTHBottomControls.tsx
@@ -63,8 +63,6 @@ const PSTHBottomControls: FunctionComponent<Props> = ({
         }}
         nwbUrl={nwbUrl}
         path={path}
-        groupByVariableCategories={groupByVariableCategories}
-        setGroupByVariableCategories={setGroupByVariableCategories}
       />
       {sep}
       {mode === "psth" && (

--- a/src/pages/NwbPage/plugins/PSTH/PSTHItemView/components/PSTHLayout.tsx
+++ b/src/pages/NwbPage/plugins/PSTH/PSTHItemView/components/PSTHLayout.tsx
@@ -1,9 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { FunctionComponent } from "react";
+import { CSSProperties, FunctionComponent } from "react";
 import UnitSelectionComponent from "./UnitSelection";
 import RoiSelectionComponent from "./RoiSelection";
 import AlignToSelectionComponent from "./AlignToSelection";
 import PrefsComponent from "./Preferences";
+import WindowRangeComponent from "./WindowRange";
+import GroupBySelectionComponent from "./GroupBySelection";
+import GroupByCategoriesComponent from "./GroupByCategories";
+import SortUnitsBySelectionComponent from "./SortUnitsBy";
+import { useCategoriesForVariable } from "../hooks/useGroupByCategories";
 import { DirectSpikeTrainsClient } from "../DirectSpikeTrainsClient";
 import { RoiClient } from "../ROIClient";
 import {
@@ -13,7 +18,15 @@ import {
 } from "../types";
 import PSTHUnitWidget from "../PSTHUnitWidget";
 import IfHasBeenVisible from "../IfHasBeenVisible";
-import PSTHBottomControls from "./PSTHBottomControls";
+
+const accordionSummaryStyle: CSSProperties = {
+  cursor: "pointer",
+  padding: "4px 8px",
+  fontWeight: "bold",
+  backgroundColor: "#34495e",
+  color: "#fff",
+  userSelect: "none",
+};
 
 type Props = {
   width: number;
@@ -77,11 +90,8 @@ const PSTHLayout: FunctionComponent<Props> = ({
   unitIdsOrRoiIndicesToPlot,
 }) => {
   const unitsTableWidth = 250;
-  const unitsTableHeight = (height * 2) / 5;
-  const prefsHeight = 150;
-  const alignToSelectionComponentHeight =
-    height - unitsTableHeight - prefsHeight;
-  const bottomAreaHeight = Math.min(70, height / 3);
+
+  const categoriesForGroupBy = useCategoriesForVariable(nwbUrl, path, groupByVariable);
 
   const unitWidgetHeight = Math.min(
     height,
@@ -115,42 +125,82 @@ const PSTHLayout: FunctionComponent<Props> = ({
         style={{
           position: "absolute",
           width: unitsTableWidth,
-          height: unitsTableHeight - 20,
+          height,
           overflowY: "auto",
+          overflowX: "hidden",
+          fontSize: "0.75em",
         }}
       >
-        {unitsTable}
-      </div>
-      <div
-        style={{
-          position: "absolute",
-          width: unitsTableWidth,
-          top: unitsTableHeight,
-          height: alignToSelectionComponentHeight,
-          overflowY: "auto",
-        }}
-      >
-        <AlignToSelectionComponent
-          alignToVariables={alignToVariables}
-          setAlignToVariables={setAlignToVariables}
-          nwbUrl={nwbUrl}
-          path={path}
-        />
-      </div>
-      <div
-        style={{
-          position: "absolute",
-          width: unitsTableWidth,
-          height: prefsHeight,
-          top: unitsTableHeight + alignToSelectionComponentHeight,
-          overflowY: "hidden",
-        }}
-      >
-        <PrefsComponent
-          prefs={prefs}
-          prefsDispatch={prefsDispatch}
-          mode={mode}
-        />
+        <details open>
+          <summary style={accordionSummaryStyle}>
+            {mode === "psth" ? "Units" : "ROIs"}
+          </summary>
+          <div style={{ maxHeight: 380, overflowY: "auto" }}>
+            {unitsTable}
+          </div>
+        </details>
+        <div style={{ height: 6 }} />
+        <details open>
+          <summary style={accordionSummaryStyle}>Align to</summary>
+          <AlignToSelectionComponent
+            alignToVariables={alignToVariables}
+            setAlignToVariables={setAlignToVariables}
+            nwbUrl={nwbUrl}
+            path={path}
+          />
+        </details>
+        <div style={{ height: 6 }} />
+        <details open>
+          <summary style={accordionSummaryStyle}>Controls</summary>
+          <div style={{ padding: "4px 8px" }}>
+            <WindowRangeComponent
+              windowRangeStr={windowRangeStr}
+              setWindowRangeStr={setWindowRangeStr}
+            />
+            <br />
+            <GroupBySelectionComponent
+              groupByVariable={groupByVariable}
+              setGroupByVariable={(v) => {
+                setGroupByVariable(v);
+                setGroupByVariableCategories(undefined);
+              }}
+              nwbUrl={nwbUrl}
+              path={path}
+            />
+            {categoriesForGroupBy && (
+              <>
+                <div style={{ height: 6 }} />
+                <details open>
+                  <summary style={accordionSummaryStyle}>
+                    Categories
+                  </summary>
+                  <GroupByCategoriesComponent
+                    groupByVariableCategories={groupByVariableCategories}
+                    setGroupByVariableCategories={setGroupByVariableCategories}
+                    options={categoriesForGroupBy}
+                  />
+                </details>
+              </>
+            )}
+            {mode === "psth" && (
+              <>
+                <br />
+                <SortUnitsBySelectionComponent
+                  sortUnitsByVariable={sortUnitsByVariable}
+                  setSortUnitsByVariable={setSortUnitsByVariable}
+                  nwbUrl={nwbUrl}
+                  unitsPath={unitsPath}
+                />
+              </>
+            )}
+            <hr style={{ margin: "6px 0", borderColor: "#dde4ed" }} />
+            <PrefsComponent
+              prefs={prefs}
+              prefsDispatch={prefsDispatch}
+              mode={mode}
+            />
+          </div>
+        </details>
       </div>
       <div
         className="psth-item-view-right"
@@ -158,7 +208,7 @@ const PSTHLayout: FunctionComponent<Props> = ({
           position: "absolute",
           left: unitsTableWidth,
           width: width - unitsTableWidth,
-          height: height - bottomAreaHeight,
+          height,
           overflowY: "auto",
           overflowX: "hidden",
         }}
@@ -204,29 +254,6 @@ const PSTHLayout: FunctionComponent<Props> = ({
             Select one or more {mode === "psth" ? "units" : "ROIs"} to plot
           </div>
         )}
-      </div>
-      <div
-        style={{ position: "absolute", top: height - bottomAreaHeight, width }}
-      >
-        <div className="psth-bottom-area">
-          <PSTHBottomControls
-            width={width}
-            height={bottomAreaHeight}
-            leftOffset={unitsTableWidth}
-            windowRangeStr={windowRangeStr}
-            setWindowRangeStr={setWindowRangeStr}
-            groupByVariable={groupByVariable}
-            setGroupByVariable={setGroupByVariable}
-            setGroupByVariableCategories={setGroupByVariableCategories}
-            nwbUrl={nwbUrl}
-            path={path}
-            groupByVariableCategories={groupByVariableCategories}
-            sortUnitsByVariable={sortUnitsByVariable}
-            setSortUnitsByVariable={setSortUnitsByVariable}
-            unitsPath={unitsPath}
-            mode={mode}
-          />
-        </div>
       </div>
     </div>
   );

--- a/src/pages/NwbPage/plugins/PSTH/PSTHItemView/components/RoiSelection.tsx
+++ b/src/pages/NwbPage/plugins/PSTH/PSTHItemView/components/RoiSelection.tsx
@@ -15,10 +15,13 @@ const RoiSelectionComponent: FunctionComponent<RoiSelectionProps> = ({
   const roiIndices = roiClient ? roiClient.getRoiIndices() : [];
 
   return (
-    <table className="nwb-table">
+    <table className="nwb-table" style={{ tableLayout: "fixed" }}>
+      <colgroup>
+        <col style={{ width: 20 }} />
+      </colgroup>
       <thead>
         <tr>
-          <th>
+          <th style={{ padding: "4px 2px" }}>
             <input
               type="checkbox"
               checked={
@@ -41,7 +44,7 @@ const RoiSelectionComponent: FunctionComponent<RoiSelectionProps> = ({
       <tbody>
         {roiIndices.map((roiIndex) => (
           <tr key={roiIndex}>
-            <td>
+            <td style={{ padding: "4px 2px" }}>
               <input
                 type="checkbox"
                 checked={selectedRoiIndices.includes(roiIndex)}

--- a/src/pages/NwbPage/plugins/PSTH/PSTHItemView/components/UnitSelection.tsx
+++ b/src/pages/NwbPage/plugins/PSTH/PSTHItemView/components/UnitSelection.tsx
@@ -21,10 +21,13 @@ const UnitSelectionComponent: FunctionComponent<UnitsSelectionProps> = ({
 }) => {
   if (!unitIds) return <div>Loading unit IDs...</div>;
   return (
-    <table className="nwb-table">
+    <table className="nwb-table" style={{ tableLayout: "fixed" }}>
+      <colgroup>
+        <col style={{ width: 20 }} />
+      </colgroup>
       <thead>
         <tr>
-          <th style={{ width: 10 }}>
+          <th style={{ padding: "4px 2px" }}>
             <input
               type="checkbox"
               checked={
@@ -48,7 +51,7 @@ const UnitSelectionComponent: FunctionComponent<UnitsSelectionProps> = ({
       <tbody>
         {unitIds.map((unitId) => (
           <tr key={unitId}>
-            <td>
+            <td style={{ padding: "4px 2px" }}>
               <input
                 type="checkbox"
                 checked={selectedUnitIds.includes(unitId)}

--- a/src/pages/NwbPage/plugins/PSTH/PSTHItemView/hooks/useGroupByCategories.ts
+++ b/src/pages/NwbPage/plugins/PSTH/PSTHItemView/hooks/useGroupByCategories.ts
@@ -1,0 +1,79 @@
+import { useMemo, useEffect, useState } from "react";
+import { useHdf5Group, getHdf5DatasetData } from "@hdf5Interface";
+
+type CategoricalOption = {
+  variableName: string;
+  categories: string[];
+};
+
+export const useCategoricalOptions = (
+  nwbUrl: string,
+  path: string,
+): CategoricalOption[] | undefined => {
+  const group = useHdf5Group(nwbUrl, path);
+  const options = useMemo(
+    () =>
+      (group?.datasets || [])
+        .map((ds) => ds.name)
+        .filter((name) => !name.endsWith("_time") && !name.endsWith("_times")),
+    [group],
+  );
+
+  const [categoricalOptions, setCategoricalOptions] = useState<
+    CategoricalOption[] | undefined
+  >(undefined);
+
+  useEffect(() => {
+    if (!group) return;
+    let canceled = false;
+    const load = async () => {
+      const result: CategoricalOption[] = [];
+      for (const option of options) {
+        const ds = group.datasets.find((ds) => ds.name === option);
+        if (!ds) continue;
+        if (ds.shape.length !== 1) continue;
+        const slice =
+          ds.shape[0] < 10000
+            ? undefined
+            : ([[0, 10000]] as [number, number][]);
+        const dd = await getHdf5DatasetData(nwbUrl, path + "/" + option, {
+          slice,
+        });
+        if (!dd) throw Error(`Unable to get data for ${path}/${option}`);
+        if (canceled) return;
+        const stringValues = [...dd].map((x) => x.toString());
+        const uniqueValues: string[] = [...new Set(stringValues)];
+        if (uniqueValues.length <= dd.length / 2) {
+          result.push({
+            variableName: option,
+            categories: uniqueValues,
+          });
+        }
+      }
+      if (canceled) return;
+      setCategoricalOptions(result);
+    };
+    load();
+    return () => {
+      canceled = true;
+    };
+  }, [options, group, nwbUrl, path]);
+
+  return categoricalOptions;
+};
+
+export const useCategoriesForVariable = (
+  nwbUrl: string,
+  path: string,
+  groupByVariable: string,
+): string[] | undefined => {
+  const categoricalOptions = useCategoricalOptions(nwbUrl, path);
+
+  return useMemo(() => {
+    if (!groupByVariable) return undefined;
+    const opt = categoricalOptions?.find(
+      (opt) => opt.variableName === groupByVariable,
+    );
+    return opt ? opt.categories : undefined;
+  }, [groupByVariable, categoricalOptions]);
+};

--- a/src/pages/NwbPage/plugins/PSTH/PSTHView.tsx
+++ b/src/pages/NwbPage/plugins/PSTH/PSTHView.tsx
@@ -1,5 +1,9 @@
 import { useCallback, useState } from "react";
 import PSTHItemView from "./PSTHItemView/PSTHItemView";
+import {
+  decodeStateFromStateString,
+  encodeStateToString,
+} from "./PSTHItemView/utils/stateEncoding";
 
 type Props = {
   nwbUrl: string;
@@ -9,26 +13,148 @@ type Props = {
   height?: number;
 };
 
-const getInitialStateFromHash = (): string | undefined => {
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const readHashParams = (): URLSearchParams => {
   const hash = window.location.hash;
-  if (!hash) return undefined;
-  const params = new URLSearchParams(hash.substring(1));
-  return params.get("psth") || undefined;
+  return new URLSearchParams(hash ? hash.substring(1) : "");
+};
+
+const stateFromHashParams = (): string | undefined => {
+  const p = readHashParams();
+  const state: Record<string, any> = {};
+  let hasAny = false;
+
+  const units = p.get("units");
+  if (units) {
+    hasAny = true;
+    if (units === "all") {
+      state.selectedUnitIds = "__all__";
+    } else {
+      state.selectedUnitIds = units.split(",").map((x) => {
+        const n = Number(x);
+        return isNaN(n) ? x : n;
+      });
+    }
+  }
+
+  const alignTo = p.get("alignTo");
+  if (alignTo) {
+    hasAny = true;
+    state.alignToVariables = alignTo.split(",");
+  }
+
+  const groupBy = p.get("groupBy");
+  if (groupBy) {
+    hasAny = true;
+    state.groupByVariable = groupBy;
+  }
+
+  const categories = p.get("categories");
+  if (categories) {
+    hasAny = true;
+    state.groupByVariableCategories = categories.split(",");
+  }
+
+  const wStart = p.get("windowStart");
+  const wEnd = p.get("windowEnd");
+  if (wStart !== null && wEnd !== null) {
+    hasAny = true;
+    state.windowRangeStr = { start: wStart, end: wEnd };
+  }
+
+  const sortBy = p.get("sortBy");
+  const sortDir = p.get("sortDir");
+  if (sortBy) {
+    hasAny = true;
+    state.sortUnitsByVariable = [sortBy, (sortDir as "asc" | "desc") || "asc"];
+  }
+
+  const showRaster = p.get("showRaster");
+  const showHist = p.get("showHist");
+  const smoothed = p.get("smoothed");
+  const numBins = p.get("numBins");
+  const height = p.get("plotHeight");
+  if (showRaster !== null || showHist !== null || smoothed !== null || numBins !== null || height !== null) {
+    hasAny = true;
+    state.prefs = {
+      showRaster: showRaster !== "0",
+      showHist: showHist !== "0",
+      smoothedHist: smoothed === "1",
+      numBins: numBins ? parseInt(numBins) : 30,
+      height: height || "small",
+    };
+  }
+
+  if (!hasAny) return undefined;
+  return encodeStateToString(state);
+};
+
+const writeHashParams = (stateString: string) => {
+  const state = decodeStateFromStateString(stateString);
+  if (!state) return;
+
+  const p = readHashParams();
+
+  // Clear old PSTH params
+  for (const key of ["units", "alignTo", "groupBy", "categories", "windowStart", "windowEnd", "sortBy", "sortDir", "showRaster", "showHist", "smoothed", "numBins", "plotHeight"]) {
+    p.delete(key);
+  }
+
+  // Units
+  if (state.selectedUnitIds === "__all__") {
+    p.set("units", "all");
+  } else if (Array.isArray(state.selectedUnitIds) && state.selectedUnitIds.length > 0) {
+    p.set("units", state.selectedUnitIds.join(","));
+  }
+
+  // Align to
+  if (state.alignToVariables && state.alignToVariables.length > 0) {
+    p.set("alignTo", state.alignToVariables.join(","));
+  }
+
+  // Group by
+  if (state.groupByVariable) {
+    p.set("groupBy", state.groupByVariable);
+  }
+  if (state.groupByVariableCategories && state.groupByVariableCategories.length > 0) {
+    p.set("categories", state.groupByVariableCategories.join(","));
+  }
+
+  // Window range
+  if (state.windowRangeStr) {
+    p.set("windowStart", state.windowRangeStr.start);
+    p.set("windowEnd", state.windowRangeStr.end);
+  }
+
+  // Sort
+  if (state.sortUnitsByVariable) {
+    p.set("sortBy", state.sortUnitsByVariable[0]);
+    p.set("sortDir", state.sortUnitsByVariable[1]);
+  }
+
+  // Prefs
+  if (state.prefs) {
+    p.set("showRaster", state.prefs.showRaster ? "1" : "0");
+    p.set("showHist", state.prefs.showHist ? "1" : "0");
+    p.set("smoothed", state.prefs.smoothedHist ? "1" : "0");
+    p.set("numBins", String(state.prefs.numBins));
+    p.set("plotHeight", state.prefs.height);
+  }
+
+  const newHash = "#" + p.toString();
+  if (window.location.hash !== newHash) {
+    window.history.replaceState(null, "", newHash);
+  }
 };
 
 const PSTHView = ({ nwbUrl, path, secondaryPaths, width, height }: Props) => {
   const [initialStateString] = useState<string | undefined>(() =>
-    getInitialStateFromHash(),
+    stateFromHashParams(),
   );
 
   const setStateString = useCallback((stateString: string) => {
-    const hash = window.location.hash;
-    const params = new URLSearchParams(hash ? hash.substring(1) : "");
-    params.set("psth", stateString);
-    const newHash = "#" + params.toString();
-    if (window.location.hash !== newHash) {
-      window.history.replaceState(null, "", newHash);
-    }
+    writeHashParams(stateString);
   }, []);
 
   return (

--- a/src/pages/NwbPage/plugins/PSTH/PSTHView.tsx
+++ b/src/pages/NwbPage/plugins/PSTH/PSTHView.tsx
@@ -53,14 +53,18 @@ const stateFromHashParams = (): string | undefined => {
   const categories = p.get("categories");
   if (categories) {
     hasAny = true;
-    state.groupByVariableCategories = categories.split(",");
+    if (categories === "all") {
+      state.groupByVariableCategories = undefined;
+    } else {
+      state.groupByVariableCategories = categories.split(",");
+    }
   }
 
   const wStart = p.get("windowStart");
   const wEnd = p.get("windowEnd");
-  if (wStart !== null && wEnd !== null) {
+  if (wStart !== null || wEnd !== null) {
     hasAny = true;
-    state.windowRangeStr = { start: wStart, end: wEnd };
+    state.windowRangeStr = { start: wStart || "-0.5", end: wEnd || "1" };
   }
 
   const sortBy = p.get("sortBy");
@@ -74,15 +78,15 @@ const stateFromHashParams = (): string | undefined => {
   const showHist = p.get("showHist");
   const smoothed = p.get("smoothed");
   const numBins = p.get("numBins");
-  const height = p.get("plotHeight");
-  if (showRaster !== null || showHist !== null || smoothed !== null || numBins !== null || height !== null) {
+  const plotHeight = p.get("plotHeight");
+  if (showRaster !== null || showHist !== null || smoothed !== null || numBins !== null || plotHeight !== null) {
     hasAny = true;
     state.prefs = {
-      showRaster: showRaster !== "0",
-      showHist: showHist !== "0",
+      showRaster: showRaster === null ? true : showRaster !== "0",
+      showHist: showHist === null ? true : showHist !== "0",
       smoothedHist: smoothed === "1",
-      numBins: numBins ? parseInt(numBins) : 30,
-      height: height || "small",
+      numBins: numBins ? parseInt(numBins) : 50,
+      height: plotHeight || "medium",
     };
   }
 
@@ -108,38 +112,47 @@ const writeHashParams = (stateString: string) => {
     p.set("units", state.selectedUnitIds.join(","));
   }
 
-  // Align to
+  // Align to (default: start_time)
   if (state.alignToVariables && state.alignToVariables.length > 0) {
-    p.set("alignTo", state.alignToVariables.join(","));
+    const isDefault = state.alignToVariables.length === 1 && state.alignToVariables[0] === "start_time";
+    if (!isDefault) {
+      p.set("alignTo", state.alignToVariables.join(","));
+    }
   }
 
   // Group by
   if (state.groupByVariable) {
     p.set("groupBy", state.groupByVariable);
   }
-  if (state.groupByVariableCategories && state.groupByVariableCategories.length > 0) {
-    p.set("categories", state.groupByVariableCategories.join(","));
+  if (state.groupByVariable) {
+    if (!state.groupByVariableCategories) {
+      p.set("categories", "all");
+    } else if (state.groupByVariableCategories.length > 0) {
+      p.set("categories", state.groupByVariableCategories.join(","));
+    }
   }
 
-  // Window range
+  // Window range (default: -0.5 to 1)
   if (state.windowRangeStr) {
-    p.set("windowStart", state.windowRangeStr.start);
-    p.set("windowEnd", state.windowRangeStr.end);
+    if (state.windowRangeStr.start !== "-0.5") p.set("windowStart", state.windowRangeStr.start);
+    if (state.windowRangeStr.end !== "1") p.set("windowEnd", state.windowRangeStr.end);
   }
 
-  // Sort
+  // Sort (default direction: asc)
   if (state.sortUnitsByVariable) {
     p.set("sortBy", state.sortUnitsByVariable[0]);
-    p.set("sortDir", state.sortUnitsByVariable[1]);
+    if (state.sortUnitsByVariable[1] !== "asc") {
+      p.set("sortDir", state.sortUnitsByVariable[1]);
+    }
   }
 
-  // Prefs
+  // Prefs (only write non-defaults)
   if (state.prefs) {
-    p.set("showRaster", state.prefs.showRaster ? "1" : "0");
-    p.set("showHist", state.prefs.showHist ? "1" : "0");
-    p.set("smoothed", state.prefs.smoothedHist ? "1" : "0");
-    p.set("numBins", String(state.prefs.numBins));
-    p.set("plotHeight", state.prefs.height);
+    if (!state.prefs.showRaster) p.set("showRaster", "0");
+    if (!state.prefs.showHist) p.set("showHist", "0");
+    if (state.prefs.smoothedHist) p.set("smoothed", "1");
+    if (state.prefs.numBins !== 50) p.set("numBins", String(state.prefs.numBins));
+    if (state.prefs.height !== "medium") p.set("plotHeight", state.prefs.height);
   }
 
   const newHash = "#" + p.toString();

--- a/src/pages/NwbPage/plugins/PSTH/PSTHView.tsx
+++ b/src/pages/NwbPage/plugins/PSTH/PSTHView.tsx
@@ -1,3 +1,4 @@
+import { useCallback, useState } from "react";
 import PSTHItemView from "./PSTHItemView/PSTHItemView";
 
 type Props = {
@@ -8,7 +9,28 @@ type Props = {
   height?: number;
 };
 
+const getInitialStateFromHash = (): string | undefined => {
+  const hash = window.location.hash;
+  if (!hash) return undefined;
+  const params = new URLSearchParams(hash.substring(1));
+  return params.get("psth") || undefined;
+};
+
 const PSTHView = ({ nwbUrl, path, secondaryPaths, width, height }: Props) => {
+  const [initialStateString] = useState<string | undefined>(() =>
+    getInitialStateFromHash(),
+  );
+
+  const setStateString = useCallback((stateString: string) => {
+    const hash = window.location.hash;
+    const params = new URLSearchParams(hash ? hash.substring(1) : "");
+    params.set("psth", stateString);
+    const newHash = "#" + params.toString();
+    if (window.location.hash !== newHash) {
+      window.history.replaceState(null, "", newHash);
+    }
+  }, []);
+
   return (
     <PSTHItemView
       width={width || 800}
@@ -16,6 +38,8 @@ const PSTHView = ({ nwbUrl, path, secondaryPaths, width, height }: Props) => {
       nwbUrl={nwbUrl}
       path={path}
       additionalPaths={secondaryPaths}
+      initialStateString={initialStateString}
+      setStateString={setStateString}
     />
   );
 };


### PR DESCRIPTION
## Summary
- Convert left panel sections (Units, Align to, Controls) into collapsible accordions
- Move bottom controls (window range, group by, sort by, display prefs) into the left panel
- Extract group-by categories into a separate accordion table that appears when a variable is selected
- Narrow checkbox columns in all selection tables
- Reduce Unit label font size and reposition to top-left of plot area
- Persist PSTH state in readable URL hash params for shareable links

## URL state persistence

When you click the **Share** button, the URL includes hash params to restore the widget state:

```
#units=all&alignTo=start_time,feedback_time&groupBy=stimulus_side&categories=all
```

Default values are omitted to keep URLs clean. See [comment on #399](https://github.com/flatironinstitute/neurosift/pull/399#issuecomment-4129837326) for full param reference.

## Test plan
- [ ] Verify accordion sections open/close correctly
- [ ] Verify units table scrolls when exceeding ~15 rows
- [ ] Verify group-by categories accordion appears/disappears when selecting/deselecting a variable
- [ ] Verify all controls work from the left panel
- [ ] Verify sharing a URL restores PSTH state on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)