### PR TITLE
Fix timeseries alignment duplicating bars on tab re-entry

### DIFF
--- a/src/pages/NwbPage/TimeseriesAlignmentView.tsx
+++ b/src/pages/NwbPage/TimeseriesAlignmentView.tsx
@@ -33,9 +33,10 @@ type TimeseriesAlignmentState = {
   timeseries: TAItem[];
 };
 
-type TimeseriesAlignmentAction =
-  | { type: "addItem"; item: TAItem }
-  | { type: "reset" };
+type TimeseriesAlignmentAction = {
+  type: "addItem";
+  item: TAItem;
+};
 
 const timeseriesAlignmentReducer = (
   state: TimeseriesAlignmentState,
@@ -47,8 +48,6 @@ const timeseriesAlignmentReducer = (
         ...state,
         timeseries: [...state.timeseries, action.item],
       };
-    case "reset":
-      return { timeseries: [] };
     default:
       return state;
   }
@@ -126,7 +125,7 @@ const TimeseriesAlignmentView: FunctionComponent<Props> = ({
   useEffect(() => {
     if (!isExpanded) return;
     if (!typeSets) return;
-    timeseriesAlignmentDispatch({ type: "reset" });
+    if (timeseriesAlignment.timeseries.length > 0) return;
     setLoadingMessage("Loading...");
     let canceled = false;
     const handleGroup = async (path: string) => {


### PR DESCRIPTION
## Summary
- Skip reloading timeseries alignment data when it has already been loaded, preventing duplicate bars from accumulating each time the tab is revisited

Fixes #402

## Test plan
- [ ] Open an NWB file and click the Timeseries Alignment tab
- [ ] Switch to another tab (e.g. Widgets), then switch back to Timeseries Alignment
- [ ] Verify bars are not duplicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)