### PR TITLE
Prefer published version and add version selector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ dist-ssr
 src/build-info.json
 
 .vite/**
+issue_401_pr_message.md

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,4 @@ dist-ssr
 src/build-info.json
 
 .vite/**
-issue_401_pr_message.md
+.codex

--- a/nextjs/neurosift-chat-agent-tools/src/lib/tools/dandi_search.ts
+++ b/nextjs/neurosift-chat-agent-tools/src/lib/tools/dandi_search.ts
@@ -43,7 +43,6 @@ export async function dandiSearch(
     // for now, let's always use draft versions
     version = item.draft_version;
 
-
     if (!version) {
       throw new Error("Failed to get version for dandiset");
     }

--- a/src/pages/DandiPage/DandisetSearchResult.tsx
+++ b/src/pages/DandiPage/DandisetSearchResult.tsx
@@ -23,10 +23,8 @@ type Props = {
 
 const DandisetSearchResult = ({ dandiset, notebookUrls }: Props) => {
   const navigate = useNavigate();
-  // const version =
-  //   dandiset.most_recent_published_version || dandiset.draft_version;
-  // for now, let's always use draft versions
-  const version = dandiset.draft_version;
+  const version =
+    dandiset.most_recent_published_version || dandiset.draft_version;
 
   return (
     <Paper

--- a/src/pages/DandisetPage/DandisetOverview.tsx
+++ b/src/pages/DandisetPage/DandisetOverview.tsx
@@ -131,26 +131,36 @@ const DandisetOverview: FunctionComponent<DandisetOverviewProps> = ({
         </Typography>
 
         {/* Version selector */}
-        {availableVersions && availableVersions.length > 1 && onVersionChange && (
-          <Box sx={{ mt: 1, mb: 1, display: "flex", alignItems: "center", gap: 1 }}>
-            <Typography variant="body2" color="text.secondary">
-              Version:
-            </Typography>
-            <FormControl size="small">
-              <Select
-                value={dandisetVersionInfo.version}
-                onChange={(e) => onVersionChange(e.target.value as string)}
-                sx={{ fontSize: "0.85rem" }}
-              >
-                {availableVersions.map((v) => (
-                  <MenuItem key={v.version} value={v.version}>
-                    {v.label}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </Box>
-        )}
+        {availableVersions &&
+          availableVersions.length > 1 &&
+          onVersionChange && (
+            <Box
+              sx={{
+                mt: 1,
+                mb: 1,
+                display: "flex",
+                alignItems: "center",
+                gap: 1,
+              }}
+            >
+              <Typography variant="body2" color="text.secondary">
+                Version:
+              </Typography>
+              <FormControl size="small">
+                <Select
+                  value={dandisetVersionInfo.version}
+                  onChange={(e) => onVersionChange(e.target.value as string)}
+                  sx={{ fontSize: "0.85rem" }}
+                >
+                  {availableVersions.map((v) => (
+                    <MenuItem key={v.version} value={v.version}>
+                      {v.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </Box>
+          )}
 
         {/* View on DANDI */}
         <Box sx={{ mt: 2, display: "flex", alignItems: "center" }}>
@@ -456,14 +466,10 @@ const DandisetOverview: FunctionComponent<DandisetOverviewProps> = ({
             </Typography>
             <Box sx={{ ml: 1, mt: 1 }}>
               {dandisetVersionInfo.metadata.assetsSummary.approach?.map(
-                (a, i) => (
-                  <div key={i}>Approach: {a.name}</div>
-                ),
+                (a, i) => <div key={i}>Approach: {a.name}</div>,
               )}
               {dandisetVersionInfo.metadata.assetsSummary.measurementTechnique?.map(
-                (t, i) => (
-                  <div key={i}>Technique: {t.name}</div>
-                ),
+                (t, i) => <div key={i}>Technique: {t.name}</div>,
               )}
             </Box>
           </Box>

--- a/src/pages/DandisetPage/DandisetOverview.tsx
+++ b/src/pages/DandisetPage/DandisetOverview.tsx
@@ -466,10 +466,14 @@ const DandisetOverview: FunctionComponent<DandisetOverviewProps> = ({
             </Typography>
             <Box sx={{ ml: 1, mt: 1 }}>
               {dandisetVersionInfo.metadata.assetsSummary.approach?.map(
-                (a, i) => <div key={i}>Approach: {a.name}</div>,
+                (a, i) => (
+                  <div key={i}>Approach: {a.name}</div>
+                ),
               )}
               {dandisetVersionInfo.metadata.assetsSummary.measurementTechnique?.map(
-                (t, i) => <div key={i}>Technique: {t.name}</div>,
+                (t, i) => (
+                  <div key={i}>Technique: {t.name}</div>
+                ),
               )}
             </Box>
           </Box>

--- a/src/pages/DandisetPage/DandisetOverview.tsx
+++ b/src/pages/DandisetPage/DandisetOverview.tsx
@@ -1,7 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import ScrollY from "@components/ScrollY";
 import { ChatBubble, MenuBook } from "@mui/icons-material";
-import { Box, IconButton, Tooltip, Typography } from "@mui/material";
+import {
+  Box,
+  FormControl,
+  IconButton,
+  MenuItem,
+  Select,
+  Tooltip,
+  Typography,
+} from "@mui/material";
 import { formatBytes } from "@shared/util/formatBytes";
 import { FunctionComponent, useCallback, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -14,10 +22,17 @@ interface NotebookInfo {
   url: string;
 }
 
+type VersionOption = {
+  version: string;
+  label: string;
+};
+
 type DandisetOverviewProps = {
   width: number;
   height: number;
   dandisetVersionInfo: DandisetVersionInfo;
+  availableVersions?: VersionOption[];
+  onVersionChange?: (version: string) => void;
 };
 
 const findNotebookInfos = (annotations: any[]): NotebookInfo[] => {
@@ -63,6 +78,8 @@ const DandisetOverview: FunctionComponent<DandisetOverviewProps> = ({
   width,
   height,
   dandisetVersionInfo,
+  availableVersions,
+  onVersionChange,
 }) => {
   const [notebooks, setNotebooks] = useState<NotebookInfo[]>([]);
   const [showNotebooksTable, setShowNotebooksTable] = useState(false);
@@ -112,6 +129,28 @@ const DandisetOverview: FunctionComponent<DandisetOverviewProps> = ({
         <Typography variant="h6" gutterBottom>
           {dandisetVersionInfo.metadata.name}
         </Typography>
+
+        {/* Version selector */}
+        {availableVersions && availableVersions.length > 1 && onVersionChange && (
+          <Box sx={{ mt: 1, mb: 1, display: "flex", alignItems: "center", gap: 1 }}>
+            <Typography variant="body2" color="text.secondary">
+              Version:
+            </Typography>
+            <FormControl size="small">
+              <Select
+                value={dandisetVersionInfo.version}
+                onChange={(e) => onVersionChange(e.target.value as string)}
+                sx={{ fontSize: "0.85rem" }}
+              >
+                {availableVersions.map((v) => (
+                  <MenuItem key={v.version} value={v.version}>
+                    {v.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Box>
+        )}
 
         {/* View on DANDI */}
         <Box sx={{ mt: 2, display: "flex", alignItems: "center" }}>

--- a/src/pages/DandisetPage/LazyDandisetPage.tsx
+++ b/src/pages/DandisetPage/LazyDandisetPage.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent, useCallback, useState } from "react";
+import { FunctionComponent, useCallback, useMemo, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import ResponsiveLayout from "@components/ResponsiveLayout";
 import DatasetWorkspace from "../common/DatasetWorkspace/DatasetWorkspace";
@@ -22,6 +22,7 @@ const LazyDandisetPage: FunctionComponent<LazyDandisetPageProps> = ({
 }) => {
   const navigate = useNavigate();
   const { dandisetId: urlDandisetId } = useParams();
+  const [searchParams] = useSearchParams();
   const effectiveDandisetId = propDandisetId || urlDandisetId;
   const staging = false;
 
@@ -31,7 +32,7 @@ const LazyDandisetPage: FunctionComponent<LazyDandisetPageProps> = ({
     staging,
     false,
   );
-  const dandisetVersion = "";
+  const dandisetVersion = searchParams.get("dandisetVersion") || "";
   const dandisetVersionInfo = useDandisetVersionInfo(
     effectiveDandisetId,
     dandisetVersion || "",
@@ -88,7 +89,6 @@ const LazyDandisetPage: FunctionComponent<LazyDandisetPageProps> = ({
     </div>
   );
 
-  const [searchParams] = useSearchParams();
   const initialTabId = searchParams.get("tab");
 
   // Register AI component
@@ -97,6 +97,28 @@ const LazyDandisetPage: FunctionComponent<LazyDandisetPageProps> = ({
     dandisetVersionInfo,
     nwbFilesOwnlyControlVisible: true,
   });
+
+  const availableVersions = useMemo(() => {
+    if (!dandisetResponse) return [];
+    const versions: { version: string; label: string }[] = [];
+    if (dandisetResponse.most_recent_published_version) {
+      const v = dandisetResponse.most_recent_published_version.version;
+      versions.push({ version: v, label: v });
+    }
+    if (dandisetResponse.draft_version) {
+      versions.push({ version: "draft", label: "draft (latest)" });
+    }
+    return versions;
+  }, [dandisetResponse]);
+
+  const handleVersionChange = useCallback(
+    (version: string) => {
+      const newParams = new URLSearchParams(searchParams);
+      newParams.set("dandisetVersion", version);
+      navigate(`?${newParams.toString()}`, { replace: true });
+    },
+    [navigate, searchParams],
+  );
 
   if (loading || !dandisetResponse || !dandisetVersionInfo) {
     return <div>Loading...</div>;
@@ -115,6 +137,8 @@ const LazyDandisetPage: FunctionComponent<LazyDandisetPageProps> = ({
         width={0}
         height={0}
         dandisetVersionInfo={dandisetVersionInfo}
+        availableVersions={availableVersions}
+        onVersionChange={handleVersionChange}
       />
       <DatasetWorkspace
         width={0}

--- a/src/pages/DandisetPage/index.tsx
+++ b/src/pages/DandisetPage/index.tsx
@@ -34,13 +34,13 @@ const DandisetPage: FunctionComponent<DandisetPageProps> = ({
 }) => {
   const navigate = useNavigate();
   const { dandisetId: urlDandisetId } = useParams();
+  const [searchParams] = useSearchParams();
   const effectiveDandisetId = propDandisetId || urlDandisetId;
   const staging = false;
   const dandisetResponse: DandisetSearchResultItem | undefined | null =
     useQueryDandiset(effectiveDandisetId, staging, false);
 
-  // todo: get dandisetVersion from the route
-  const dandisetVersion = "";
+  const dandisetVersion = searchParams.get("dandisetVersion") || "";
 
   const dandisetVersionInfo: DandisetVersionInfo | null =
     useDandisetVersionInfo(
@@ -50,8 +50,6 @@ const DandisetPage: FunctionComponent<DandisetPageProps> = ({
       dandisetResponse || null,
       false,
     );
-
-  // todo: set dandisetVersion to route if not there yet
 
   const [maxNumPages, setMaxNumPages] = useState(1);
   const [nwbFilesOnly, setNwbFilesOnly] = useState(false);
@@ -265,7 +263,6 @@ const DandisetPage: FunctionComponent<DandisetPageProps> = ({
     </div>
   );
 
-  const [searchParams] = useSearchParams();
   const initialTabId = searchParams.get("tab");
 
   // Register AI component
@@ -274,6 +271,28 @@ const DandisetPage: FunctionComponent<DandisetPageProps> = ({
     dandisetVersionInfo,
     nwbFilesOwnlyControlVisible,
   });
+
+  const availableVersions = useMemo(() => {
+    if (!dandisetResponse) return [];
+    const versions: { version: string; label: string }[] = [];
+    if (dandisetResponse.most_recent_published_version) {
+      const v = dandisetResponse.most_recent_published_version.version;
+      versions.push({ version: v, label: v });
+    }
+    if (dandisetResponse.draft_version) {
+      versions.push({ version: "draft", label: "draft (latest)" });
+    }
+    return versions;
+  }, [dandisetResponse]);
+
+  const handleVersionChange = useCallback(
+    (version: string) => {
+      const newParams = new URLSearchParams(searchParams);
+      newParams.set("dandisetVersion", version);
+      navigate(`?${newParams.toString()}`, { replace: true });
+    },
+    [navigate, searchParams],
+  );
 
   if (!dandisetResponse || !dandisetVersionInfo) {
     return <div>Loading...</div>;
@@ -292,6 +311,8 @@ const DandisetPage: FunctionComponent<DandisetPageProps> = ({
         width={0}
         height={0}
         dandisetVersionInfo={dandisetVersionInfo}
+        availableVersions={availableVersions}
+        onVersionChange={handleVersionChange}
       />
       <DatasetWorkspace
         width={0}

--- a/src/pages/DandisetPage/useDandisetVersionInfo.ts
+++ b/src/pages/DandisetPage/useDandisetVersionInfo.ts
@@ -21,6 +21,7 @@ export const useDandisetVersionInfo = (
     (async () => {
       const { most_recent_published_version, draft_version } =
         dandisetResponse || {};
+      // Prefer the latest published version; fall back to draft if unpublished
       const V = most_recent_published_version || draft_version;
       const dsVersion = dandisetVersion || (V ? V.version : "draft");
       const dvi = await fetchDandisetVersionInfo(

--- a/src/pages/DandisetPage/useDandisetVersionInfo.ts
+++ b/src/pages/DandisetPage/useDandisetVersionInfo.ts
@@ -19,11 +19,9 @@ export const useDandisetVersionInfo = (
     setDandisetVersionInfo(null);
     if (!dandisetResponse) return;
     (async () => {
-      // const { most_recent_published_version, draft_version } =
-      const { draft_version } = dandisetResponse || {};
-      // const V = most_recent_published_version || draft_version;
-      // for now, let's always use draft versions
-      const V = draft_version;
+      const { most_recent_published_version, draft_version } =
+        dandisetResponse || {};
+      const V = most_recent_published_version || draft_version;
       const dsVersion = dandisetVersion || (V ? V.version : "draft");
       const dvi = await fetchDandisetVersionInfo(
         dandisetId || "",

--- a/src/pages/EmberDandisetPage/useEmberDandisetVersionInfo.ts
+++ b/src/pages/EmberDandisetPage/useEmberDandisetVersionInfo.ts
@@ -18,11 +18,9 @@ export const useEmberDandisetVersionInfo = (
     setDandisetVersionInfo(null);
     if (!dandisetResponse) return;
     (async () => {
-      // const { most_recent_published_version, draft_version } =
-      const { draft_version } = dandisetResponse || {};
-      // const V = most_recent_published_version || draft_version;
-      // for now, let's always use draft versions
-      const V = draft_version;
+      const { most_recent_published_version, draft_version } =
+        dandisetResponse || {};
+      const V = most_recent_published_version || draft_version;
       const dsVersion = dandisetVersion || (V ? V.version : "draft");
       const dvi = await fetchDandisetVersionInfo(
         dandisetId || "",

--- a/src/pages/EmberPage/EmberDandisetSearchResult.tsx
+++ b/src/pages/EmberPage/EmberDandisetSearchResult.tsx
@@ -23,10 +23,8 @@ type Props = {
 
 const EmberDandisetSearchResult = ({ dandiset, notebookUrls }: Props) => {
   const navigate = useNavigate();
-  // const version =
-  //   dandiset.most_recent_published_version || dandiset.draft_version;
-  // for now, let's always use draft versions
-  const version = dandiset.draft_version;
+  const version =
+    dandiset.most_recent_published_version || dandiset.draft_version;
 
   return (
     <Paper

--- a/src/pages/NwbPage/NwbOverview.tsx
+++ b/src/pages/NwbPage/NwbOverview.tsx
@@ -1,3 +1,4 @@
+import { FormControl, MenuItem, Select } from "@mui/material";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { DandisetVersionInfo } from "../DandiPage/dandi-types";
@@ -9,11 +10,18 @@ import NwbAnnotations from "./components/NwbAnnotations";
 
 type NwbFileOverviewResult = NwbFileOverview | { error: string } | null;
 
+type VersionOption = {
+  version: string;
+  label: string;
+};
+
 type NwbOverviewProps = {
   nwbFileOverview: NwbFileOverviewResult;
   nwbUrl: string | null;
   dandisetInfo: DandisetVersionInfo | null;
   width: number;
+  availableVersions?: VersionOption[];
+  onVersionChange?: (version: string) => void;
 };
 
 const MAX_DESCRIPTION_LENGTH = 150;
@@ -24,6 +32,8 @@ export const NwbOverview = ({
   nwbUrl,
   dandisetInfo,
   width,
+  availableVersions,
+  onVersionChange,
 }: NwbOverviewProps) => {
   const navigate = useNavigate();
   const [showFullDescription, setShowFullDescription] = useState(false);
@@ -70,8 +80,7 @@ export const NwbOverview = ({
       {dandisetInfo && (
         <div style={{ marginBottom: 15, fontSize: "0.8em" }}>
           <h3 style={{ marginBottom: 8 }}>
-            Dandiset {dandisetInfo.dandiset.identifier} (v.
-            {dandisetInfo.version}) - {dandisetInfo.metadata.name}{" "}
+            Dandiset {dandisetInfo.dandiset.identifier} - {dandisetInfo.metadata.name}{" "}
             <span
               style={{
                 fontSize: "0.8em",
@@ -87,6 +96,28 @@ export const NwbOverview = ({
               (view)
             </span>
           </h3>
+          {availableVersions && availableVersions.length > 1 && onVersionChange ? (
+            <div style={{ marginBottom: 8, display: "flex", alignItems: "center", gap: 8 }}>
+              <span style={{ color: "rgba(0, 0, 0, 0.6)" }}>Version:</span>
+              <FormControl size="small">
+                <Select
+                  value={dandisetInfo.version}
+                  onChange={(e) => onVersionChange(e.target.value as string)}
+                  sx={{ fontSize: "0.8rem" }}
+                >
+                  {availableVersions.map((v) => (
+                    <MenuItem key={v.version} value={v.version}>
+                      {v.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            </div>
+          ) : (
+            <div style={{ marginBottom: 8, fontSize: "0.8em" }}>
+              Version: {dandisetInfo.version}
+            </div>
+          )}
           <table style={tableStyle}>
             <tbody>
               <tr>

--- a/src/pages/NwbPage/NwbOverview.tsx
+++ b/src/pages/NwbPage/NwbOverview.tsx
@@ -80,7 +80,8 @@ export const NwbOverview = ({
       {dandisetInfo && (
         <div style={{ marginBottom: 15, fontSize: "0.8em" }}>
           <h3 style={{ marginBottom: 8 }}>
-            Dandiset {dandisetInfo.dandiset.identifier} - {dandisetInfo.metadata.name}{" "}
+            Dandiset {dandisetInfo.dandiset.identifier} -{" "}
+            {dandisetInfo.metadata.name}{" "}
             <span
               style={{
                 fontSize: "0.8em",
@@ -96,8 +97,17 @@ export const NwbOverview = ({
               (view)
             </span>
           </h3>
-          {availableVersions && availableVersions.length > 1 && onVersionChange ? (
-            <div style={{ marginBottom: 8, display: "flex", alignItems: "center", gap: 8 }}>
+          {availableVersions &&
+          availableVersions.length > 1 &&
+          onVersionChange ? (
+            <div
+              style={{
+                marginBottom: 8,
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+              }}
+            >
               <span style={{ color: "rgba(0, 0, 0, 0.6)" }}>Version:</span>
               <FormControl size="small">
                 <Select

--- a/src/pages/NwbPage/NwbPage.tsx
+++ b/src/pages/NwbPage/NwbPage.tsx
@@ -1,5 +1,5 @@
 import { Box, Tab, Tabs } from "@mui/material";
-import { FunctionComponent, useEffect, useState } from "react";
+import { FunctionComponent, useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import useRegisterNwbAIComponent from "./useRegisterNwbAIComponent";
 import ResponsiveLayout from "@components/ResponsiveLayout";
@@ -171,6 +171,8 @@ const LeftArea: FunctionComponent<LeftAreaProps> = ({
   dandisetVersion,
   useEmber,
 }) => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const dandisetResponse = useQueryDandiset(dandisetId, false, useEmber);
   const dandisetVersionInfo = useDandisetVersionInfo(
     dandisetId,
@@ -182,6 +184,28 @@ const LeftArea: FunctionComponent<LeftAreaProps> = ({
   const { nwbFileOverview } = useNwbFileOverview(nwbUrl);
   const tabBarHeight = TAB_BAR_HEIGHT;
   const contentHeight = height - tabBarHeight;
+
+  const availableVersions = useMemo(() => {
+    if (!dandisetResponse) return [];
+    const versions: { version: string; label: string }[] = [];
+    if (dandisetResponse.most_recent_published_version) {
+      const v = dandisetResponse.most_recent_published_version.version;
+      versions.push({ version: v, label: v });
+    }
+    if (dandisetResponse.draft_version) {
+      versions.push({ version: "draft", label: "draft (latest)" });
+    }
+    return versions;
+  }, [dandisetResponse]);
+
+  const handleVersionChange = useCallback(
+    (version: string) => {
+      const newParams = new URLSearchParams(searchParams);
+      newParams.set("dandisetVersion", version);
+      navigate(`?${newParams.toString()}`, { replace: true });
+    },
+    [navigate, searchParams],
+  );
 
   useRegisterNwbAIComponent({
     nwbUrl,
@@ -218,6 +242,8 @@ const LeftArea: FunctionComponent<LeftAreaProps> = ({
           nwbUrl={nwbUrl}
           dandisetInfo={dandisetVersionInfo}
           width={width - 20}
+          availableVersions={availableVersions}
+          onVersionChange={handleVersionChange}
         />
       </ScrollY>
     </div>

--- a/src/pages/NwbPage/NwbPage.tsx
+++ b/src/pages/NwbPage/NwbPage.tsx
@@ -1,5 +1,11 @@
 import { Box, Tab, Tabs } from "@mui/material";
-import { FunctionComponent, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  FunctionComponent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import useRegisterNwbAIComponent from "./useRegisterNwbAIComponent";
 import ResponsiveLayout from "@components/ResponsiveLayout";


### PR DESCRIPTION
Neurosift previously hardcoded "draft" as the version for all dandisets in the explorer UI. This PR defaults to the most recent published version when one exists (falling back to draft for unpublished dandisets) and adds version selectors so users can switch between versions.

Version selectors (MUI Select dropdowns) appear in two places: below the dataset name on the dandiset page, and below the dandiset header on the NWB file page. Both show the published version and "draft (latest)" when multiple versions exist. Selecting a version updates the `?dandisetVersion=` URL query parameter, making version selection shareable via links. Existing links with `?dandisetVersion=draft` continue to work.

<img width="1113" height="757" alt="image" src="https://github.com/user-attachments/assets/7949d43b-2b35-4368-9e7a-7ee5535f76b2" />

<img width="1113" height="757" alt="image" src="https://github.com/user-attachments/assets/39b46221-2cf6-4878-8ce7-818af442efcb" />


Closes #401
