### PR TITLE
Play external-file videos for local NWB files

### DIFF
--- a/python/neurosift/cli.py
+++ b/python/neurosift/cli.py
@@ -22,7 +22,16 @@ def neurosift():
     default="https://neurosift.app",
     help="Neurosift server URL (default: https://neurosift.app)",
 )
-def view_nwb(file: str, neurosift_url: str):
+@click.option(
+    "--video",
+    "videos",
+    multiple=True,
+    type=click.Path(exists=True),
+    help="External video file referenced by an ImageSeries external_file. "
+    "Repeatable. Placed next to the NWB so it can be played locally. "
+    "The filename must match the external_file basename in the NWB.",
+)
+def view_nwb(file: str, neurosift_url: str, videos: tuple[str, ...]):
     abs_fname = os.path.abspath(file)
     base_fname = os.path.basename(abs_fname)
     with TemporaryDirectory(prefix="view_nwb") as tmpdir:
@@ -32,6 +41,25 @@ def view_nwb(file: str, neurosift_url: str):
         else:
             # create a symbolic link to the file (or zarr folder)
             os.symlink(abs_fname, f"{tmpdir}/{base_fname}")
+
+        # Place any --video files next to the NWB by basename, so an ImageSeries
+        # external_file (which neurosift resolves to its basename for local files)
+        # is served at /files/<basename> alongside the NWB.
+        seen = {base_fname}
+        for video in videos:
+            video_abs = os.path.abspath(video)
+            video_base = os.path.basename(video_abs)
+            if video_base in seen:
+                raise click.ClickException(
+                    f"Duplicate video filename '{video_base}'. "
+                    "Each --video must have a unique filename."
+                )
+            seen.add(video_base)
+            target = f"{tmpdir}/{video_base}"
+            if sys.platform == "win32":
+                shutil.copy2(video_abs, target)
+            else:
+                os.symlink(video_abs, target)
 
         # this directory
         this_directory = os.path.dirname(os.path.realpath(__file__))

--- a/src/pages/NwbPage/externalVideoUtils.ts
+++ b/src/pages/NwbPage/externalVideoUtils.ts
@@ -116,6 +116,17 @@ export const resolveExternalVideoFromFile = async (
     return externalFile;
   }
 
+  // Local files served by `neurosift view-nwb`: the CLI symlinks the referenced
+  // video into the same directory it serves, by basename, so resolve external_file
+  // to its basename as a sibling of the NWB URL. This handles any stored path
+  // shape (relative, "../", absolute POSIX, or Windows) uniformly. Scoped to
+  // localhost (the view-nwb case we control), matching RemoteH5File.dataIsRemote.
+  if (nwbUrl.startsWith("http://localhost")) {
+    const base =
+      externalFile.replace(/\\/g, "/").split("/").pop() || externalFile;
+    return new URL(base, nwbUrl).href;
+  }
+
   if (!isDandiAssetUrl(nwbUrl)) {
     throw new Error(
       "Only absolute URLs and DANDI-hosted relative external_file paths are supported in this first version.",


### PR DESCRIPTION
I have been building several video-related widgets,the single-video widget (#408), the multi-video player (#410), the pose-estimation widget (#417) and a draft VAME view (#418), and one limitation I kept hitting was that there is no way to mount videos on the local file server. This PR adds that.

https://github.com/flatironinstitute/neurosift/pull/418

Two use cases:
1) Testing edge cases: sometimes there is no file on DANDI with the characteristics needed to exercise a particular case, so mounting a local video lets me develop and preview these widgets against arbitrary local files.
2) Local-only users: people who run neurosift on their own files (via `neurosift view-nwb`) can now use these video widgets too, which are currently DANDI-only.

To enable this, we add a repeatable `--video` option to `neurosift view-nwb` that serves the named video(s) next to the NWB on the local file server, plus a small frontend change that resolves an `ImageSeries` `external_file` to the served file, so the single-video, multi-video, and pose widgets all work locally. Each video is served under its basename, so the file you pass must match the `external_file` basename referenced in the NWB.
