### PR TITLE
Exclude single-value columns from PSTH "Group trials by" dropdown

### DIFF
--- a/src/pages/NwbPage/plugins/PSTH/PSTHItemView/hooks/useGroupByCategories.ts
+++ b/src/pages/NwbPage/plugins/PSTH/PSTHItemView/hooks/useGroupByCategories.ts
@@ -43,6 +43,9 @@ export const useCategoricalOptions = (
         if (canceled) return;
         const stringValues = [...dd].map((x) => x.toString());
         const uniqueValues: string[] = [...new Set(stringValues)];
+        // Skip columns that have only a single unique value -- grouping by
+        // them is meaningless.
+        if (uniqueValues.length < 2) continue;
         if (uniqueValues.length <= dd.length / 2) {
           result.push({
             variableName: option,


### PR DESCRIPTION
## Summary

In the PSTH widget, the **"Group trials by:"** dropdown previously listed columns even when they only contained a single unique value. Grouping by such a column is meaningless (it produces a single group).

This change skips any column with fewer than 2 unique values when building the categorical options list in `useCategoricalOptions`.

## Example

PSTH view on dandiset 001868 — before this change, the "Group trials by:" dropdown included columns with only a single value.

- **Before** (production): https://neurosift.app/nwb?url=https://api.dandiarchive.org/api/assets/6b0eea5e-bd83-4d45-b7ae-a4212ad12c80/download/&dandisetId=001868&dandisetVersion=draft&tab=view:PSTH|/intervals/electrical_stimulation^/units#units=all&groupBy=stim_channel&categories=all
- **After** (preview deployment): https://exclude-single-value-groupby.neurosift.pages.dev/nwb?url=https://api.dandiarchive.org/api/assets/6b0eea5e-bd83-4d45-b7ae-a4212ad12c80/download/&dandisetId=001868&dandisetVersion=draft&tab=view:PSTH|/intervals/electrical_stimulation^/units#units=all&groupBy=stim_channel&categories=all

## Testing

- Ran the dev server and confirmed the dropdown no longer shows constant-valued columns on the example PSTH view above.

Note: for columns longer than 10,000 rows, uniqueness is determined from the first 10,000 sampled values, consistent with the existing category-detection logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)