### PR TITLE
Fix read more button wrapping in hierarchy Description column

### DIFF
--- a/src/pages/NwbPage/NwbHierarchyView.tsx
+++ b/src/pages/NwbPage/NwbHierarchyView.tsx
@@ -128,7 +128,7 @@ const NwbHierarchyView: FunctionComponent<Props> = ({
         return (
           <span>
             {text}
-            <span
+            <button
               onClick={(e) => {
                 e.stopPropagation();
                 setExpandedDescriptions((prev) => {
@@ -138,14 +138,17 @@ const NwbHierarchyView: FunctionComponent<Props> = ({
                 });
               }}
               style={{
-                marginLeft: "5px",
-                color: "#007bff",
+                marginLeft: 8,
+                background: "none",
+                border: "none",
+                color: "#0066cc",
                 cursor: "pointer",
+                padding: "2px 4px",
                 fontSize: "0.9em",
               }}
             >
               show less
-            </span>
+            </button>
           </span>
         );
       }
@@ -153,7 +156,7 @@ const NwbHierarchyView: FunctionComponent<Props> = ({
       return (
         <span>
           {text.slice(0, maxLength)}...
-          <span
+          <button
             onClick={(e) => {
               e.stopPropagation();
               setExpandedDescriptions((prev) => {
@@ -163,14 +166,17 @@ const NwbHierarchyView: FunctionComponent<Props> = ({
               });
             }}
             style={{
-              marginLeft: "5px",
-              color: "#007bff",
+              marginLeft: 8,
+              background: "none",
+              border: "none",
+              color: "#0066cc",
               cursor: "pointer",
+              padding: "2px 4px",
               fontSize: "0.9em",
             }}
           >
             read more
-          </span>
+          </button>
         </span>
       );
     },


### PR DESCRIPTION
## Problem

In the NWB hierarchy view table, the **read more** / **show less** control in the DESCRIPTION column was wrapping onto two lines.

## Cause

The CSS rule in `src/css/NwbHierarchyView.css`:

```css
.nwb-hierarchy-table span[style*="cursor: pointer"] {
    width: 16px;
    display: inline-block;
    ...
}
```

was intended for the single-character expand arrows (▼/►), but it also matched the `read more`/`show less` `<span>`s (which set `cursor: pointer` inline). That forced the multi-character label into a 16px-wide inline-block, wrapping it onto a second line.

## Fix

Convert the `read more`/`show less` elements from `<span>` to `<button>`, styled like the left-panel "Experiment description" read-more in `DatasetDataView.tsx` (`background: none`, `border: none`, `color: #0066cc`, `padding: 2px 4px`, `fontSize: 0.9em`). Buttons aren't matched by the arrow CSS rule, so they render inline on a single line, with consistent aesthetics across the app. The expand arrows keep their intended styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)