### PR TITLE
Fix HDF5 tab clipped off the right edge of the workspace

### DIFF
--- a/src/components/tabs/TabBar.tsx
+++ b/src/components/tabs/TabBar.tsx
@@ -138,7 +138,7 @@ export const TabBar = <T extends BaseTab>({
       <div
         style={{
           position: "absolute",
-          width,
+          width: width - 20,
           left: 10,
           top: 12,
         }}


### PR DESCRIPTION
## Problem

The **HDF5** button (in the secondary fixed-tab group) was rendered partially off the right edge of the window and clipped.

## Cause

In `src/components/tabs/TabBar.tsx`, the fixed-tab bar `<div>` is positioned at `left: 10` but given the full `width`, so its right edge lands at `10 + width` — 10px past the available area. The `flex: 1` spacer pushes the secondary group (Schema, HDF5) hard against that right edge, so the HDF5 button overflows and gets clipped by the parent's `overflow: hidden`.

## Fix

Use `width - 20` for the tab-bar container so it has symmetric 10px margins on both sides — matching the content area below it (which already uses `left: 10, width: width - 20`). The secondary tabs now sit fully within the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)