### PR TITLE
Stop NAME column from over-expanding in hierarchy view

### DIFF
--- a/src/pages/NwbPage/NwbHierarchyView.tsx
+++ b/src/pages/NwbPage/NwbHierarchyView.tsx
@@ -400,7 +400,7 @@ const NwbHierarchyView: FunctionComponent<Props> = ({
             )}
           </div>
         </td>
-        <td style={{ maxWidth: "400px" }}>
+        <td style={{ width: "100%" }}>
           {truncateDescription(obj.attrs.description || "", obj.path)}
         </td>
       </tr>


### PR DESCRIPTION
## Problem

In the NWB widgets (hierarchy) view, the **NAME** column was given far more width than its content needs, leaving the other columns cramped.

Example: https://neurosift.app/nwb?url=https%3A%2F%2Fapi.dandiarchive.org%2Fapi%2Fassets%2F5feb1944-d1d9-4344-9911-d64a1ea8f9bc%2Fdownload%2F&dandisetId=001693&dandisetVersion=draft

## Cause

The table is `width: 100%`, but no column was designated to absorb the extra width. The Description cell had `maxWidth: 400px`, capping it — so the leftover table width spilled into the first column (NAME).

## Fix

Give the Description column `width: 100%` so it absorbs the remaining space, letting the NAME and Neurodata Type columns shrink to fit their content. Descriptions are already truncated (200 chars + read more), so dropping the 400px cap doesn't cause runaway-width rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)