### PR TITLE
Fix dandi-index job runner startup crashes

### DIFF
--- a/python/dandi-index/dandi-index-query-job-runner/package.json
+++ b/python/dandi-index/dandi-index-query-job-runner/package.json
@@ -4,7 +4,7 @@
   "description": "Job runner for executing DANDI index queries",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && cp src/systemMessage.txt dist/",
     "start": "node dist/index.js",
     "dev": "ts-node src/index.ts",
     "watch": "tsc -w"

--- a/python/dandi-index/dandi-index-query-job-runner/src/index.ts
+++ b/python/dandi-index/dandi-index-query-job-runner/src/index.ts
@@ -1,8 +1,7 @@
-import { config } from 'dotenv';
+// Load environment variables from .env file BEFORE importing ./jobRunner,
+// which transitively constructs the OpenAI client at module-load time.
+import 'dotenv/config';
 import { JobRunner } from './jobRunner';
-
-// Load environment variables from .env file
-config();
 
 const {
   PUBNUB_SUBSCRIBE_KEY,


### PR DESCRIPTION
The `dandi-index-query-job-runner` crashed on startup after a clean build, taking script execution on chat.neurosift.app offline. Two independent bugs:

1. **dotenv loaded too late.** `src/index.ts` called `config()` *after* importing `./jobRunner`. Imports run first, and `scriptInterface.ts` constructs the OpenAI client at module-load time, so it threw on an empty `OPENAI_API_KEY` before `.env` was read. Fixed by making `import 'dotenv/config'` the first import.

2. **Build didn't include systemMessage.txt.** `tsc` does not copy non-`.ts` files, but `jobRunner.ts` does `readFileSync(dist/systemMessage.txt)` at load, causing an ENOENT crash. Build now copies it into `dist/`.

Verified end-to-end: runner boots, connects to PubNub, and a submitted script returns output.