### PR TITLE
Refresh OpenNeuro index alongside DANDI in job-runner data update

### DIFF
--- a/python/dandi-index/deploy/README.md
+++ b/python/dandi-index/deploy/README.md
@@ -68,11 +68,22 @@ python3 -m venv ~/neurosift-venv
 ~/neurosift-venv/bin/pip install --upgrade pip
 ~/neurosift-venv/bin/pip install openai requests h5py lindi   # add pynwb remfile for --assets
 
+# DANDI index
 cd ~/neurosift/python/dandi-index
 ~/neurosift-venv/bin/python scripts/update_data.py               # base (~2-3 min, 600+ dandisets)
 ~/neurosift-venv/bin/python scripts/update_data.py --embeddings  # optional: enables semanticSortDandisets
 ~/neurosift-venv/bin/python scripts/update_data.py --assets      # optional: slow, per-asset NWB metadata
+
+# OpenNeuro index (required for getOpenNeuroDatasets — the runner reads
+# ../../openneuro-index/data/openneuro.json). No credentials needed.
+cd ~/neurosift/python/openneuro-index
+~/neurosift-venv/bin/python scripts/update_data.py               # base (public openneuro.org GraphQL API)
+~/neurosift-venv/bin/python scripts/update_data.py --embeddings  # optional: enables semanticSortOpenNeuroDatasets
 ```
+
+EBRAINS (`getEbrainsDatasets`) is not covered here: its build needs an EBRAINS
+auth `TOKEN` and the `kg_core` package, so it is a separate manual step and
+those queries will error until it is built.
 
 Then return to root: `exit`.
 
@@ -104,9 +115,11 @@ printf '%s\n%s\n' '0 */6 * * * /home/neurosift/neurosift/python/dandi-index/depl
 crontab -l
 ```
 
-That refreshes the base index every 6 hours (`update_data.py` self-skips work
-that is still fresh) and embeddings daily at 04:30 UTC. The wrapper uses
-`~/neurosift-venv/bin/python` by default; override with `DANDI_INDEX_PYTHON`.
+That refreshes the base indexes (both DANDI and OpenNeuro) every 6 hours
+(`update_data.py` self-skips work that is still fresh) and embeddings daily at
+04:30 UTC. `--assets` applies to DANDI only; the OpenNeuro build has no asset
+pass. The wrapper uses `~/neurosift-venv/bin/python` by default; override with
+`DANDI_INDEX_PYTHON`.
 
 ## Updating the runner code later
 

--- a/python/dandi-index/deploy/update-index-data.sh
+++ b/python/dandi-index/deploy/update-index-data.sh
@@ -1,31 +1,55 @@
 #!/usr/bin/env bash
 #
-# Refresh the DANDI / OpenNeuro / EBRAINS index data consumed by the job runner.
+# Refresh the DANDI / OpenNeuro index data consumed by the job runner.
 # Intended to be run from cron. The job runner reads these JSON files fresh on
 # every request, so the service does NOT need restarting after this runs.
 #
 # Usage:
-#   update-index-data.sh                 # base refresh (dandi.json + per-dandiset)
+#   update-index-data.sh                 # base refresh (dandi + openneuro)
 #   update-index-data.sh --embeddings    # also refresh embeddings (needs OPENAI_API_KEY)
-#   update-index-data.sh --assets        # also refresh per-asset NWB metadata (slow)
+#   update-index-data.sh --assets        # also refresh per-asset NWB metadata (DANDI only, slow)
+#
+# Both the DANDI and OpenNeuro indexes are refreshed. --embeddings applies to
+# both; --assets applies to DANDI only (the OpenNeuro build has no asset pass).
+# EBRAINS is intentionally NOT refreshed here: its build needs an EBRAINS auth
+# TOKEN and the kg_core package, so it is a separate manual step.
 #
 # Point DANDI_INDEX_PYTHON at a python that has: openai requests h5py lindi
 # (add pynwb/remfile if you use --assets).
 set -euo pipefail
 
-# cd to <repo>/python/dandi-index (this script lives in deploy/ one level down)
-cd "$(dirname "$(readlink -f "$0")")/.."
+# Resolve the directory layout. This script lives in
+# <repo>/python/dandi-index/deploy/, so:
+DEPLOY_DIR="$(dirname "$(readlink -f "$0")")"   # python/dandi-index/deploy
+DANDI_DIR="$DEPLOY_DIR/.."                       # python/dandi-index
+PY_ROOT="$DANDI_DIR/.."                          # python
 
 # The embeddings build reads OPENAI_API_KEY from the environment. Load it (and
 # the PubNub keys) from the runner's .env so this works under cron, which does
 # NOT source ~/.bashrc. Harmless for the base/--assets refreshes.
-ENV_FILE="dandi-index-query-job-runner/.env"
+ENV_FILE="$DANDI_DIR/dandi-index-query-job-runner/.env"
 if [ -f "$ENV_FILE" ]; then
-  set -a; . "./$ENV_FILE"; set +a
+  set -a; . "$ENV_FILE"; set +a
 fi
 
 PYTHON="${DANDI_INDEX_PYTHON:-$HOME/neurosift-venv/bin/python}"
 
-echo "[$(date -u +%FT%TZ)] update-index-data.sh $* (python=$PYTHON, cwd=$(pwd))"
+# Detect --embeddings so we can forward it to the OpenNeuro build (which does
+# NOT understand --assets, so we never forward "$@" verbatim there).
+EMB=""
+for a in "$@"; do
+  if [ "$a" = "--embeddings" ]; then EMB="--embeddings"; fi
+done
+
+echo "[$(date -u +%FT%TZ)] update-index-data.sh $* (python=$PYTHON)"
+
+echo "[$(date -u +%FT%TZ)] -- DANDI index ($DANDI_DIR)"
+cd "$DANDI_DIR"
 "$PYTHON" scripts/update_data.py "$@"
+
+echo "[$(date -u +%FT%TZ)] -- OpenNeuro index ($PY_ROOT/openneuro-index)"
+cd "$PY_ROOT/openneuro-index"
+# shellcheck disable=SC2086  # $EMB is intentionally word-split (empty -> no arg)
+"$PYTHON" scripts/update_data.py $EMB
+
 echo "[$(date -u +%FT%TZ)] done"


### PR DESCRIPTION
The chat.neurosift.app job runner serves `getOpenNeuroDatasets` from `../../openneuro-index/data/openneuro.json`, but the deploy runbook and cron wrapper only built the DANDI index. Any OpenNeuro query failed with "OpenNeuro data file not found".

- `update-index-data.sh` now refreshes both the DANDI and OpenNeuro base indexes. `--embeddings` applies to both; `--assets` stays DANDI-only (the OpenNeuro build has no asset pass, so `$@` is not forwarded verbatim to it).
- `README.md` documents the OpenNeuro base/embeddings build during initial provisioning and notes EBRAINS remains a separate credentialed step (needs an EBRAINS `TOKEN` + `kg_core`).

OpenNeuro's build needs only `requests` (already in the venv) and no credentials.