### PR TITLE
Label boolean and bigint group values in the PSTH legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## August 5, 2026
+
+- PSTH group legend now labels boolean and bigint group values instead of showing "?"
+
 ## March 13, 2026
 
 - Show dataset chunking and compression in HDF5 view

--- a/src/pages/NwbPage/plugins/PSTH/PSTHItemView/PSTHUnitWidget.tsx
+++ b/src/pages/NwbPage/plugins/PSTH/PSTHItemView/PSTHUnitWidget.tsx
@@ -613,17 +613,23 @@ type GroupLabelProps = {
 
 const GroupLabel: FunctionComponent<GroupLabelProps> = ({ group }) => {
   if (!group) return <></>;
-  else if (typeof group.group === "number") {
-    return <>{group.group}</>;
-  } else if (typeof group.group === "string") {
-    return <>{group.group}</>;
-  } else if (typeof group.group === "object") {
-    if (group.group._REFERENCE) {
+  const value = group.group;
+  if (typeof value === "number" || typeof value === "string") {
+    return <>{value}</>;
+  } else if (typeof value === "boolean" || typeof value === "bigint") {
+    // A boolean trials column (e.g. "rewarded") comes back as JS booleans, and a
+    // 64-bit integer column can come back as bigints. React renders neither of
+    // those directly, so they have to be stringified. Without this the legend
+    // fell through to the "?" case below.
+    return <>{value.toString()}</>;
+  } else if (value && typeof value === "object") {
+    if (value._REFERENCE) {
       return <>_REF</>;
     } else {
       return <>_OBJ</>;
     }
   } else {
+    // null / undefined / anything else we have no sensible label for
     return <>?</>;
   }
 };


### PR DESCRIPTION
Fixes #335.

`GroupLabel` in `PSTHUnitWidget.tsx` branches on `typeof` for `number`, `string` and `object`, and falls through to a literal `?` for anything else. A boolean trials column such as `rewarded` arrives as JS booleans, so it hit the fallback. That is consistent with the report: the group selectors below the plot are built from `x.toString()` and showed `true` and `false` correctly, while the legend showed `?`. React does not render a raw boolean either, so the value has to be stringified.

This handles `boolean` and `bigint` explicitly. It also guards the object branch against `null`, which previously threw a `TypeError` reading `_REFERENCE` off it, since `typeof null === "object"`.

The repo has no test harness, vitest was added and reverted within #433, so I did not add one. Instead I rendered both the old and new branch chains through the repo's own `react-dom/server`:

```
value                        before          after
boolean false (issue #335)   "?"             "false"
boolean true  (issue #335)   "?"             "true"
bigint 7n                    "?"             "7"
number 3                     "3"             "3"
string 'go'                  "go"            "go"
object _REFERENCE            "_REF"          "_REF"
object plain                 "_OBJ"          "_OBJ"
null                         THREW TypeError "?"

BEFORE: 4 failures   AFTER: 0 failures
```

`prettier --check` and `eslint` are clean. `tsc -b` produces an error set byte identical to the pristine baseline, 9 pre-existing errors from a `Types/` directory colliding with `types.ts` on a case insensitive filesystem plus an uninitialized `niivue_dist` submodule, both macOS local rather than repo bugs.

CHANGELOG.md updated per `.clinerules`.

Disclosure: this change was prepared with AI assistance. I have reviewed and tested it.
