### PR TITLE
Fall back to a relative time axis when starting_time is NaN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## August 5, 2026
+
+- Show a relative time axis instead of an empty plot when a TimeSeries has a NaN `starting_time`
+
 ## March 13, 2026
 
 - Show dataset chunking and compression in HDF5 view

--- a/src/shared/TimeseriesTimestampsClient/TimeseriesTimestampsClient.ts
+++ b/src/shared/TimeseriesTimestampsClient/TimeseriesTimestampsClient.ts
@@ -128,6 +128,19 @@ export class RegularTimeseriesTimestampsClient {
         `Problem getting starting_time dataset: ${this.objectPath}/starting_time`,
       );
     }
+    if (isNaN(startingTime)) {
+      // A NaN starting_time means the absolute timing of this series is not
+      // known (some conversions write NaN when the relative timing between
+      // series is unavailable). Previously the NaN flowed into startTime and
+      // endTime, every downstream time comparison came out false, and
+      // getDataIndexForTime returned NaN, so the data layer rejected the slice
+      // and the user got an empty plot with no explanation. Fall back to a
+      // relative time axis starting at zero instead.
+      console.warn(
+        `starting_time is NaN for ${this.objectPath}; treating it as 0 and showing a relative time axis.`,
+      );
+      startingTime = 0;
+    }
     const dataDataset = await getHdf5Dataset(
       this.nwbUrl,
       `${this.objectPath}/data`,


### PR DESCRIPTION
Fixes #316.

`RegularTimeseriesTimestampsClient.initialize` guards `starting_time` with an `isNumber` check, but that is `typeof data === "number"` and `typeof NaN === "number"`, so NaN passed the guard and became `startTime` and `endTime`. Every downstream comparison against NaN is false, so `getDataIndexForTime` returned NaN, and `RemoteH5File.getDatasetData` then rejected the read with `Invalid slice`. The user saw an empty plot with only a console warning.

Some conversions write NaN when the absolute timing of a series is not known. This treats that as an unknown offset: warn, and use zero so the trace is drawn on a relative time axis, which is what the issue asks for. Series with a real `starting_time` are untouched. The sibling `IrregularTimeseriesTimestampsClient` already special cases a NaN final timestamp, so NaN in the time fields is a known hazard in this file.

If you would rather this raise a clear error than substitute zero, that is a one line change and I am happy to make it.

The repo has no test harness, vitest was added and reverted within #433, so I did not add one. Instead I ran a harness replicating the client arithmetic plus the real slice guard, with `starting_time=NaN`, `rate=1000`, 10 s:

```
BEFORE: startTime=NaN endTime=NaN indices=[NaN,NaN] read=THREW Invalid slice   -> 5 failures
AFTER:  startTime=0   endTime=10    indices=[0,1000] read=ok                    -> 0 failures
```

Three of the assertions confirm a normal `starting_time=12.5` series is unaffected, and they pass in both modes.

`prettier` and `eslint` are clean, and `tsc -b` is identical to the baseline. CHANGELOG.md updated per `.clinerules`.

Disclosure: this change was prepared with AI assistance. I have reviewed and tested it.
