### PR TITLE
Show the image viewer for Image subtype datasets

### DIFF
--- a/src/pages/NwbPage/plugins/Image/ImagePluginView.tsx
+++ b/src/pages/NwbPage/plugins/Image/ImagePluginView.tsx
@@ -1,5 +1,6 @@
 import { useHdf5Dataset, useHdf5Group } from "@hdf5Interface";
 import ImagesItemView, { ImageItem } from "./ImagesItemView";
+import { imageDatasetNeurodataTypes } from "./imageNeurodataTypes";
 
 type Props = {
   nwbUrl: string;
@@ -43,9 +44,7 @@ const ImagePluginViewDataset: React.FC<Props> = ({ nwbUrl, path }) => {
   const dataset = useHdf5Dataset(nwbUrl, path);
   if (!dataset) return <div>Loading dataset...</div>;
   const neurodataType = dataset.attrs.neurodata_type;
-  if (
-    ["Image", "GrayscaleImage", "RGBImage", "RGBAImage"].includes(neurodataType)
-  ) {
+  if (imageDatasetNeurodataTypes.includes(neurodataType)) {
     return (
       <ImageItem nwbUrl={nwbUrl} path={path} neurodataType={neurodataType} />
     );

--- a/src/pages/NwbPage/plugins/Image/imageNeurodataTypes.ts
+++ b/src/pages/NwbPage/plugins/Image/imageNeurodataTypes.ts
@@ -1,0 +1,7 @@
+// Neurodata types of datasets that ImageItem knows how to render
+export const imageDatasetNeurodataTypes = [
+  "Image",
+  "GrayscaleImage",
+  "RGBImage",
+  "RGBAImage",
+];

--- a/src/pages/NwbPage/plugins/Image/index.ts
+++ b/src/pages/NwbPage/plugins/Image/index.ts
@@ -1,6 +1,7 @@
 import { getHdf5Dataset, getHdf5Group } from "@hdf5Interface";
 import { NwbObjectViewPlugin } from "../pluginInterface";
 import ImagePluginView from "./ImagePluginView";
+import { imageDatasetNeurodataTypes } from "./imageNeurodataTypes";
 
 export const imagePlugin: NwbObjectViewPlugin = {
   name: "Image",
@@ -15,7 +16,8 @@ export const imagePlugin: NwbObjectViewPlugin = {
   }) => {
     if (objectType === "dataset") {
       const ds = await getHdf5Dataset(nwbUrl, path);
-      if (ds?.attrs.neurodata_type === "Image") return true;
+      if (ds && imageDatasetNeurodataTypes.includes(ds.attrs.neurodata_type))
+        return true;
     } else {
       // objectType === "group"
       const grp = await getHdf5Group(nwbUrl, path);


### PR DESCRIPTION
Addresses #440.

## Problem

`ImagePluginView` and `ImageItem` already know how to render `Image`, `GrayscaleImage`, `RGBImage`, and `RGBAImage`, but the plugin's `canHandle` in `plugins/Image/index.ts` tested `neurodata_type === "Image"` exactly. A `GrayscaleImage`, `RGBImage`, or `RGBAImage` dataset selected directly therefore failed plugin selection and fell through to `defaultPlugin`. These types rendered only when reached through a parent `Images` group, because `ImagesItemView` iterates the group's children and dispatches on each child's `neurodata_type` itself, bypassing `canHandle`.

## Change

`canHandle` accepts any of the four types. The list moved to a new `imageNeurodataTypes.ts` so plugin selection and view dispatch share one definition rather than keeping separate copies that can drift. It is a separate module because exporting a non-component from a component file trips `react-refresh/only-export-components`.

No rendering code changed.

## Verification

`tsc -b` output is byte identical to the pre-change baseline on this checkout (11 pre-existing errors, none in the Image plugin). `eslint` and `prettier --check` are clean on `src/pages/NwbPage/plugins/Image/`.

This has not been exercised against a live NWB file. The code path is the same one already reached through an `Images` group, so the risk is low, but a runtime check against a DANDI asset with a standalone `GrayscaleImage` dataset would be worth doing before merge.

## Out of scope

The second half of #440 (resolving `neurodata_type_inc` chains so any subtype of X gets X's visualization, including unknown extension types) is not addressed here. Two notes for whoever picks it up:

1. `specifications` is already threaded into `canHandle`, and `spatialSeriesPlugin` uses it for a one level subtype check. However, `specifications` is missing from the dependency arrays of two of the three `findSuitablePlugins` call sites (`NwbObjectView.tsx:80` and `NwbHierarchyView.tsx:120`). It is `undefined` until `loadSpecifications` resolves, and those effects never re-run when it arrives, so subtype matching silently no-ops depending on mount timing. This is worst for deep links (`?url=...&tab=/path`), where the view mounts before the specifications load. That likely affects `spatialSeriesPlugin` today.
2. `spatialSeriesPlugin` scans only `specifications.allGroups`. The image subtypes are datasets, so a general implementation needs `allDatasets` too.

Separately, `RGBImageItem` and `RGBAImageItem` copy raw values into the canvas buffer with no scaling, while `GrayscaleImageItem` windows against the data max. Since the schema declares `dtype: numeric` for all three, float or uint16 RGB data renders as near black or blown out white. Happy to send that as a follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
