### PR TITLE
Match neurodata types through the schema inheritance hierarchy

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,6 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git*,*.svg,**/package-lock.json,*.css,.codespellrc,static
+skip = .git*,*.svg,package-lock.json,**/package-lock.json,*.css,.codespellrc,static
 check-hidden = true
 ignore-regex = \btempory\.net\b
 ignore-words-list = numer,breal,anser,lIK

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,8 @@
         "prettier": "^3.3.2",
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.18.2",
-        "vite": "^6.0.5"
+        "vite": "^6.0.5",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2360,9 +2361,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2377,9 +2375,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2394,9 +2389,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2411,9 +2403,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2428,9 +2417,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2445,9 +2431,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2462,9 +2445,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2479,9 +2459,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2496,9 +2473,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2513,9 +2487,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2530,9 +2501,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2547,9 +2515,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2564,9 +2529,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2683,6 +2645,13 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
@@ -2808,6 +2777,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -2816,6 +2796,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3389,6 +3376,126 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -3623,6 +3730,16 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/ast-types": {
       "version": "0.13.4",
@@ -4044,6 +4161,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -4998,6 +5125,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -5393,6 +5527,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5441,6 +5585,16 @@
       "peer": true,
       "engines": {
         "node": ">=0.8.x"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -7471,6 +7625,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -9246,6 +9410,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -9522,6 +9700,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pbf": {
       "version": "3.3.0",
@@ -9911,8 +10096,9 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "extraneous": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -10961,6 +11147,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -11112,6 +11305,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
@@ -11151,6 +11351,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-parser": {
       "version": "0.3.1",
@@ -11456,12 +11663,29 @@
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinycolor2": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
@@ -11485,6 +11709,16 @@
       "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
       "license": "ISC",
       "peer": true
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -11988,6 +12222,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/vlq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.1.tgz",
@@ -12117,6 +12441,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx}\"",
-    "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx}\""
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx}\"",
+    "test": "vitest run"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -51,6 +52,7 @@
     "prettier": "^3.3.2",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.18.2",
-    "vite": "^6.0.5"
+    "vite": "^6.0.5",
+    "vitest": "^4.1.10"
   }
 }

--- a/src/pages/NwbPage/MainWorkspace.tsx
+++ b/src/pages/NwbPage/MainWorkspace.tsx
@@ -19,6 +19,7 @@ import AuthErrorNotification from "./components/AuthErrorNotification";
 import { DynamicTab } from "./Types/index";
 import { getHdf5Group, hasAuthError, isDandiAssetUrl } from "./hdf5Interface";
 import { SetupNwbFileSpecificationsProvider } from "./SpecificationsView/SetupNwbFileSpecificationsProvider";
+import { neurodataTypeInheritsFrom } from "./neurodataTypeInheritance";
 import ScrollY from "@components/ScrollY";
 import NwbHierarchyView from "./NwbHierarchyView";
 import Hdf5View from "./Hdf5View";
@@ -146,7 +147,12 @@ const MainWorkspace: React.FC<MainWorkspaceProps> = ({
   useEffect(() => {
     const checkUnits = async () => {
       const group = await getHdf5Group(nwbUrl, "/units");
-      if (group && group.attrs.neurodata_type === "Units") {
+      // No specifications available here (the provider is set up below this
+      // component), so this falls back to the known core type relationships
+      if (
+        group &&
+        neurodataTypeInheritsFrom(group.attrs.neurodata_type, "Units")
+      ) {
         setDefaultUnitsPath("/units");
       }
     };

--- a/src/pages/NwbPage/MultiVideoTabView.tsx
+++ b/src/pages/NwbPage/MultiVideoTabView.tsx
@@ -20,6 +20,8 @@ import {
 } from "./externalVideoUtils";
 
 import { useSearchParams } from "react-router-dom";
+import { neurodataTypeInheritsFrom } from "./neurodataTypeInheritance";
+import { useNwbFileSpecifications } from "./SpecificationsView/SetupNwbFileSpecificationsProvider";
 
 type Props = {
   nwbUrl: string;
@@ -27,8 +29,6 @@ type Props = {
   height: number;
   isExpanded?: boolean;
 };
-
-const SUPPORTED_TYPES = new Set(["ImageSeries"]);
 
 const START_TOLERANCE_SEC = 0.25;
 const DRIFT_TOLERANCE_SEC = 0.1;
@@ -290,6 +290,7 @@ const MultiVideoTabView: FunctionComponent<Props> = ({
   isExpanded,
 }) => {
   const [searchParams, setSearchParams] = useSearchParams();
+  const specifications = useNwbFileSpecifications();
   const [candidates, setCandidates] = useState<ExternalVideoCandidate[]>([]);
   const [loading, setLoading] = useState(false);
   const [loadingMessage, setLoadingMessage] = useState("");
@@ -408,7 +409,11 @@ const MultiVideoTabView: FunctionComponent<Props> = ({
 
       const neurodataType = group.attrs?.neurodata_type;
       if (
-        SUPPORTED_TYPES.has(neurodataType) &&
+        neurodataTypeInheritsFrom(
+          neurodataType,
+          "ImageSeries",
+          specifications,
+        ) &&
         group.datasets.some((ds) => ds.name === "external_file")
       ) {
         try {
@@ -464,7 +469,7 @@ const MultiVideoTabView: FunctionComponent<Props> = ({
     return () => {
       canceled = true;
     };
-  }, [nwbUrl, isExpanded]);
+  }, [nwbUrl, isExpanded, specifications]);
 
   const labelMap = useMemo(() => {
     const map = new Map<string, string>();

--- a/src/pages/NwbPage/NwbHierarchyView.tsx
+++ b/src/pages/NwbPage/NwbHierarchyView.tsx
@@ -10,6 +10,7 @@ import { NeurodataObject, useNeurodataObjects } from "./useNeurodataObjects";
 import { findSuitablePlugins } from "./plugins/registry";
 import { NwbObjectViewPlugin } from "./plugins/pluginInterface";
 import { useNwbFileSpecifications } from "./SpecificationsView/SetupNwbFileSpecificationsProvider";
+import { neurodataTypeInheritsFrom } from "./neurodataTypeInheritance";
 
 type Props = {
   nwbUrl: string;
@@ -118,7 +119,7 @@ const NwbHierarchyView: FunctionComponent<Props> = ({
       );
     };
     loadLaunchablePlugins();
-  }, [nwbUrl, neurodataObjects, defaultUnitsPath]);
+  }, [nwbUrl, neurodataObjects, defaultUnitsPath, specifications]);
 
   useEffect(() => {
     const checkInteractiveViews = async () => {
@@ -425,7 +426,11 @@ const NwbHierarchyView: FunctionComponent<Props> = ({
             >
               {obj.attrs.neurodata_type || "-"}
             </span>
-            {obj.attrs.neurodata_type === "Units" && (
+            {neurodataTypeInheritsFrom(
+              obj.attrs.neurodata_type,
+              "Units",
+              specifications,
+            ) && (
               <span
                 onClick={(e) => {
                   e.stopPropagation();

--- a/src/pages/NwbPage/NwbObjectView.tsx
+++ b/src/pages/NwbPage/NwbObjectView.tsx
@@ -79,7 +79,7 @@ const NwbObjectView: React.FC<NwbObjectViewProps> = ({
       }
     };
     loadPlugin();
-  }, [path, objectType, nwbUrl, plugin, inMultiView]);
+  }, [path, objectType, nwbUrl, plugin, inMultiView, specifications]);
 
   if (loading) {
     return <CircularProgress />;

--- a/src/pages/NwbPage/TimeseriesAlignmentView.tsx
+++ b/src/pages/NwbPage/TimeseriesAlignmentView.tsx
@@ -14,6 +14,10 @@ import {
   useNwbFileSpecifications,
   NwbFileSpecifications,
 } from "./SpecificationsView/SetupNwbFileSpecificationsProvider";
+import {
+  neurodataTypeInheritsFrom,
+  neurodataTypeInheritsFromAny,
+} from "./neurodataTypeInheritance";
 
 type Props = {
   nwbUrl: string;
@@ -73,33 +77,24 @@ const timeseriesRootPaths = new Set([
 const buildTypeSets = (
   specs: NwbFileSpecifications,
 ): { relevantTypes: Set<string>; containerTypes: Set<string> } => {
-  const parentOf: Record<string, string> = {};
-  for (const g of specs.allGroups) {
-    if (g.neurodata_type_inc) {
-      parentOf[g.neurodata_type_def] = g.neurodata_type_inc;
-    }
-  }
-  const descendsFrom = (type: string, ancestor: string): boolean => {
-    let current: string | undefined = type;
-    while (current) {
-      if (current === ancestor) return true;
-      current = parentOf[current];
-    }
-    return false;
-  };
   const relevantTypes = new Set<string>();
   const containerTypes = new Set<string>();
   for (const g of specs.allGroups) {
     const def = g.neurodata_type_def;
     if (
-      descendsFrom(def, "TimeSeries") ||
-      descendsFrom(def, "TimeIntervals") ||
-      descendsFrom(def, "Events")
+      neurodataTypeInheritsFromAny(
+        def,
+        ["TimeSeries", "TimeIntervals", "Events"],
+        specs,
+      )
     ) {
       relevantTypes.add(def);
     } else if (
-      descendsFrom(def, "NWBDataInterface") ||
-      descendsFrom(def, "ProcessingModule")
+      neurodataTypeInheritsFromAny(
+        def,
+        ["NWBDataInterface", "ProcessingModule"],
+        specs,
+      )
     ) {
       containerTypes.add(def);
     }
@@ -222,7 +217,9 @@ const TimeseriesAlignmentView: FunctionComponent<Props> = ({
               });
             }
           }
-        } else if (nt === "TimeIntervals") {
+        } else if (
+          neurodataTypeInheritsFrom(nt, "TimeIntervals", specifications)
+        ) {
           const startTimeDataset = gr.datasets?.find(
             (ds: any) => ds.name === "start_time",
           );
@@ -340,7 +337,7 @@ const TimeseriesAlignmentView: FunctionComponent<Props> = ({
     return () => {
       canceled = true;
     };
-  }, [nwbUrl, isExpanded, typeSets]);
+  }, [nwbUrl, isExpanded, typeSets, specifications]);
 
   const { startTime, endTime } = useMemo(() => {
     let startTime: number | undefined = undefined;

--- a/src/pages/NwbPage/components/NwbUsageScript.tsx
+++ b/src/pages/NwbPage/components/NwbUsageScript.tsx
@@ -10,6 +10,7 @@ import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vs } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { getLindiUrl } from "../hdf5Interface";
 import createUsageScriptForNwbFile from "./createUsageScriptForNwbFile";
+import { useNwbFileSpecifications } from "../SpecificationsView/SetupNwbFileSpecificationsProvider";
 
 type Props = {
   nwbUrl: string;
@@ -17,6 +18,7 @@ type Props = {
 };
 
 const NwbUsageScript: FunctionComponent<Props> = ({ nwbUrl, onNwbUsage }) => {
+  const specifications = useNwbFileSpecifications();
   const [scriptContent, setScriptContent] = useState<string | undefined>(
     undefined,
   );
@@ -73,14 +75,14 @@ nwb = pynwb.NWBHDF5IO(file=f, mode='r').read()
     const getUsageScript = async () => {
       if (!nwbUrl) return;
       try {
-        const x = await createUsageScriptForNwbFile(nwbUrl);
+        const x = await createUsageScriptForNwbFile(nwbUrl, specifications);
         setScriptContent(x);
       } catch (error) {
         setError(`Error creating usage script: ${error}`);
       }
     };
     getUsageScript();
-  }, [nwbUrl]);
+  }, [nwbUrl, specifications]);
 
   const handleCopyClick = useCallback(() => {
     if (!headerContent || !scriptContent) return;

--- a/src/pages/NwbPage/components/createUsageScriptForNwbFile.ts
+++ b/src/pages/NwbPage/components/createUsageScriptForNwbFile.ts
@@ -405,10 +405,7 @@ const createUsageScriptForNwbFile = async (
         specifications,
       )
     ) {
-      const dataDataset = obj.group.datasets.find((x) => x.name === "data");
-      if (dataDataset) {
-        s += `${obj.variableName}.data # (h5py.Dataset) shape ${shapeToString(dataDataset.shape)}; dtype ${dataDataset.dtype}\n`;
-      }
+      // The .data line is covered by the generic TimeSeries block above
       const indexedImages = obj.group.subgroups.find(
         (x) => x.name === "indexed_images",
       );

--- a/src/pages/NwbPage/components/createUsageScriptForNwbFile.ts
+++ b/src/pages/NwbPage/components/createUsageScriptForNwbFile.ts
@@ -5,8 +5,16 @@ import {
   getHdf5Group,
 } from "@hdf5Interface";
 import { RemoteH5Group } from "@remote-h5-file";
+import {
+  neurodataTypeInheritsFrom,
+  neurodataTypeInheritsFromAny,
+} from "../neurodataTypeInheritance";
+import { NwbFileSpecifications } from "../SpecificationsView/SetupNwbFileSpecificationsProvider";
 
-const createUsageScriptForNwbFile = async (nwbUrl: string) => {
+const createUsageScriptForNwbFile = async (
+  nwbUrl: string,
+  specifications?: NwbFileSpecifications,
+) => {
   let s = "";
 
   // session_description
@@ -185,14 +193,18 @@ const createUsageScriptForNwbFile = async (nwbUrl: string) => {
           group,
         });
         if (
-          [
-            "ProcessingModule",
-            "LFP",
-            "Fluorescence",
-            "ImageSegmentation",
-            "PupilTracking",
-            "EyeTracking",
-          ].includes(neurodataType)
+          neurodataTypeInheritsFromAny(
+            neurodataType,
+            [
+              "ProcessingModule",
+              "LFP",
+              "Fluorescence",
+              "ImageSegmentation",
+              "PupilTracking",
+              "EyeTracking",
+            ],
+            specifications,
+          )
         ) {
           await processContainerGroup(group, objectExpression);
         }
@@ -259,15 +271,19 @@ const createUsageScriptForNwbFile = async (nwbUrl: string) => {
     s += `\n`;
     s += `${obj.variableName} = ${obj.objectExpression} # (${obj.neurodataType}) ${obj.description}\n`;
 
-    // TimeSeries or ElectricalSeries or RoiResponseSeries or SpatialSeries
+    // Generic TimeSeries data line. Excludes OnePhotonSeries/TwoPhotonSeries,
+    // which print their own more detailed data line below.
     if (
-      [
+      neurodataTypeInheritsFrom(
+        obj.neurodataType,
         "TimeSeries",
-        "ElectricalSeries",
-        "RoiResponseSeries",
-        "SpatialSeries",
-        "PoseEstimationSeries",
-      ].includes(obj.neurodataType)
+        specifications,
+      ) &&
+      !neurodataTypeInheritsFromAny(
+        obj.neurodataType,
+        ["OnePhotonSeries", "TwoPhotonSeries"],
+        specifications,
+      )
     ) {
       const dataDataset = obj.group.datasets.find((x) => x.name === "data");
 
@@ -276,7 +292,13 @@ const createUsageScriptForNwbFile = async (nwbUrl: string) => {
       }
     }
 
-    if (obj.neurodataType === "ElectricalSeries") {
+    if (
+      neurodataTypeInheritsFrom(
+        obj.neurodataType,
+        "ElectricalSeries",
+        specifications,
+      )
+    ) {
       const electrodesDataset = obj.group.datasets.find(
         (x) => x.name === "electrodes",
       );
@@ -294,7 +316,13 @@ const createUsageScriptForNwbFile = async (nwbUrl: string) => {
     }
 
     // ImageSeries
-    if (["ImageSeries"].includes(obj.neurodataType)) {
+    if (
+      neurodataTypeInheritsFrom(
+        obj.neurodataType,
+        "ImageSeries",
+        specifications,
+      )
+    ) {
       const externalFileDataset = obj.group.datasets.find(
         (x) => x.name === "external_file",
       );
@@ -304,13 +332,25 @@ const createUsageScriptForNwbFile = async (nwbUrl: string) => {
     }
 
     // TimeIntervals
-    if (obj.neurodataType === "TimeIntervals") {
+    if (
+      neurodataTypeInheritsFrom(
+        obj.neurodataType,
+        "TimeIntervals",
+        specifications,
+      )
+    ) {
       for (const ds of obj.group.datasets) {
         s += `${obj.variableName}["${ds.name}"] # (h5py.Dataset) shape ${shapeToString(ds.shape)}; dtype ${ds.dtype} ${ds.attrs.description}\n`;
       }
     }
 
-    if (["OnePhotonSeries", "TwoPhotonSeries"].includes(obj.neurodataType)) {
+    if (
+      neurodataTypeInheritsFromAny(
+        obj.neurodataType,
+        ["OnePhotonSeries", "TwoPhotonSeries"],
+        specifications,
+      )
+    ) {
       // TODO: handle imaging plane more thoroughly. Example: https://neurosift.app/nwb?url=https://api.dandiarchive.org/api/assets/193fee16-550e-4a8f-aab8-2383f6d57a03/download/&dandisetId=001174&dandisetVersion=draft
       s += `${obj.variableName}.imaging_plane # (ImagingPlane)\n`;
       const dataDataset = obj.group.datasets.find((x) => x.name === "data");
@@ -323,7 +363,13 @@ const createUsageScriptForNwbFile = async (nwbUrl: string) => {
       }
     }
 
-    if (["PlaneSegmentation"].includes(obj.neurodataType)) {
+    if (
+      neurodataTypeInheritsFrom(
+        obj.neurodataType,
+        "PlaneSegmentation",
+        specifications,
+      )
+    ) {
       const imageMaskDataset = await getHdf5Dataset(
         nwbUrl,
         `${obj.group.path}/image_mask`,
@@ -334,23 +380,31 @@ const createUsageScriptForNwbFile = async (nwbUrl: string) => {
     }
 
     // Units
-    if (obj.neurodataType === "Units") {
+    if (neurodataTypeInheritsFrom(obj.neurodataType, "Units", specifications)) {
       handleUnits(obj.group, `${obj.objectExpression}`);
     }
 
     // Images
-    if (obj.neurodataType === "Images") {
+    if (
+      neurodataTypeInheritsFrom(obj.neurodataType, "Images", specifications)
+    ) {
       for (const ds of obj.group.datasets) {
         const nt = ds.attrs.neurodata_type;
         const description = ds.attrs.description || "";
-        if (nt === "GrayscaleImage") {
+        if (neurodataTypeInheritsFrom(nt, "Image", specifications)) {
           s += `${obj.variableName}["${ds.name}"].data # (h5py.Dataset) shape ${shapeToString(ds.shape)}; dtype ${ds.dtype}; ${description}\n`;
         }
       }
     }
 
     // IndexSeries
-    if (obj.neurodataType === "IndexSeries") {
+    if (
+      neurodataTypeInheritsFrom(
+        obj.neurodataType,
+        "IndexSeries",
+        specifications,
+      )
+    ) {
       const dataDataset = obj.group.datasets.find((x) => x.name === "data");
       if (dataDataset) {
         s += `${obj.variableName}.data # (h5py.Dataset) shape ${shapeToString(dataDataset.shape)}; dtype ${dataDataset.dtype}\n`;

--- a/src/pages/NwbPage/externalVideoUtils.ts
+++ b/src/pages/NwbPage/externalVideoUtils.ts
@@ -5,6 +5,7 @@ import {
   isDandiAssetUrl,
 } from "./hdf5Interface";
 import getAuthorizationHeaderForUrl from "../util/getAuthorizationHeaderForUrl";
+import { neurodataTypeInheritsFrom } from "./neurodataTypeInheritance";
 
 export type ExternalVideoCandidate = {
   path: string;
@@ -350,7 +351,8 @@ export const hasExternalVideos = async (nwbUrl: string): Promise<boolean> => {
     const group = await getHdf5Group(nwbUrl, path);
     if (!group) return false;
     if (
-      group.attrs?.neurodata_type === "ImageSeries" &&
+      // No specifications available here; falls back to core relationships
+      neurodataTypeInheritsFrom(group.attrs?.neurodata_type, "ImageSeries") &&
       group.datasets.some((ds) => ds.name === "external_file")
     ) {
       return true;

--- a/src/pages/NwbPage/neurodataTypeInheritance.test.ts
+++ b/src/pages/NwbPage/neurodataTypeInheritance.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import {
+  getNeurodataTypeAncestry,
+  getNeurodataTypeParentMap,
+  neurodataTypeInheritsFrom,
+  neurodataTypeInheritsFromAny,
+} from "./neurodataTypeInheritance";
+import { NwbFileSpecifications } from "./SpecificationsView/SetupNwbFileSpecificationsProvider";
+
+const makeSpecifications = (o: {
+  groups?: { def: string; inc?: string }[];
+  datasets?: { def: string; inc?: string }[];
+}): NwbFileSpecifications => ({
+  subgroups: [],
+  allNamespaces: [],
+  allGroups: (o.groups || []).map((g) => ({
+    doc: "",
+    default_name: "",
+    neurodata_type_def: g.def,
+    neurodata_type_inc: g.inc,
+  })),
+  allDatasets: (o.datasets || []).map((d) => ({
+    doc: "",
+    neurodata_type_def: d.def,
+    neurodata_type_inc: d.inc,
+  })),
+});
+
+describe("neurodataTypeInheritsFrom", () => {
+  it("matches a type against itself", () => {
+    expect(neurodataTypeInheritsFrom("TimeSeries", "TimeSeries")).toBe(true);
+  });
+
+  it("does not match unrelated types", () => {
+    expect(neurodataTypeInheritsFrom("TimeSeries", "DynamicTable")).toBe(false);
+  });
+
+  it("returns false for undefined type", () => {
+    expect(neurodataTypeInheritsFrom(undefined, "TimeSeries")).toBe(false);
+  });
+
+  it("matches one level of inheritance from specifications (groups)", () => {
+    const specs = makeSpecifications({
+      groups: [{ def: "MySeries", inc: "TimeSeries" }],
+    });
+    expect(neurodataTypeInheritsFrom("MySeries", "TimeSeries", specs)).toBe(
+      true,
+    );
+  });
+
+  it("matches one level of inheritance from specifications (datasets)", () => {
+    const specs = makeSpecifications({
+      datasets: [{ def: "MyImage", inc: "RGBImage" }],
+    });
+    expect(neurodataTypeInheritsFrom("MyImage", "RGBImage", specs)).toBe(true);
+  });
+
+  it("matches transitively through multiple levels", () => {
+    const specs = makeSpecifications({
+      groups: [
+        { def: "MySpecialSeries", inc: "MySeries" },
+        { def: "MySeries", inc: "TimeSeries" },
+      ],
+    });
+    expect(
+      neurodataTypeInheritsFrom("MySpecialSeries", "TimeSeries", specs),
+    ).toBe(true);
+  });
+
+  it("matches transitively through spec chain into the core fallback chain", () => {
+    // Extension subtypes RGBImage; RGBImage -> Image comes from the fallback map
+    const specs = makeSpecifications({
+      datasets: [{ def: "MyRGBImage", inc: "RGBImage" }],
+    });
+    expect(neurodataTypeInheritsFrom("MyRGBImage", "Image", specs)).toBe(true);
+  });
+
+  it("uses core fallback relationships when specifications are unavailable", () => {
+    expect(neurodataTypeInheritsFrom("GrayscaleImage", "Image")).toBe(true);
+    expect(neurodataTypeInheritsFrom("TwoPhotonSeries", "ImageSeries")).toBe(
+      true,
+    );
+    expect(neurodataTypeInheritsFrom("TwoPhotonSeries", "TimeSeries")).toBe(
+      true,
+    );
+    expect(neurodataTypeInheritsFrom("Units", "DynamicTable")).toBe(true);
+  });
+
+  it("lets file specifications take precedence over the fallback map", () => {
+    // Pathological case: file spec says GrayscaleImage extends RGBImage
+    const specs = makeSpecifications({
+      datasets: [{ def: "GrayscaleImage", inc: "RGBImage" }],
+    });
+    expect(neurodataTypeInheritsFrom("GrayscaleImage", "RGBImage", specs)).toBe(
+      true,
+    );
+  });
+
+  it("does not loop on cyclic specifications", () => {
+    const specs = makeSpecifications({
+      groups: [
+        { def: "A", inc: "B" },
+        { def: "B", inc: "A" },
+      ],
+    });
+    expect(neurodataTypeInheritsFrom("A", "C", specs)).toBe(false);
+    expect(neurodataTypeInheritsFrom("A", "B", specs)).toBe(true);
+  });
+});
+
+describe("getNeurodataTypeAncestry", () => {
+  it("returns the chain ordered from the type itself upward", () => {
+    const specs = makeSpecifications({
+      groups: [{ def: "MyTwoPhotonSeries", inc: "TwoPhotonSeries" }],
+    });
+    expect(getNeurodataTypeAncestry("MyTwoPhotonSeries", specs)).toEqual([
+      "MyTwoPhotonSeries",
+      "TwoPhotonSeries",
+      "ImageSeries",
+      "TimeSeries",
+    ]);
+  });
+
+  it("supports lowest-parent resolution against a supported set", () => {
+    const specs = makeSpecifications({
+      datasets: [{ def: "MyRGBImage", inc: "RGBImage" }],
+    });
+    const supported = ["GrayscaleImage", "RGBImage", "RGBAImage", "Image"];
+    const resolved = getNeurodataTypeAncestry("MyRGBImage", specs).find((t) =>
+      supported.includes(t),
+    );
+    // The nearest supported ancestor wins, not the more general Image
+    expect(resolved).toBe("RGBImage");
+  });
+
+  it("returns an empty chain for undefined", () => {
+    expect(getNeurodataTypeAncestry(undefined)).toEqual([]);
+  });
+});
+
+describe("neurodataTypeInheritsFromAny", () => {
+  it("matches when any base matches", () => {
+    expect(
+      neurodataTypeInheritsFromAny("TwoPhotonSeries", [
+        "DynamicTable",
+        "ImageSeries",
+      ]),
+    ).toBe(true);
+  });
+
+  it("does not match when no base matches", () => {
+    expect(
+      neurodataTypeInheritsFromAny("TwoPhotonSeries", [
+        "DynamicTable",
+        "Units",
+      ]),
+    ).toBe(false);
+  });
+});
+
+describe("getNeurodataTypeParentMap", () => {
+  it("caches per specifications object", () => {
+    const specs = makeSpecifications({
+      groups: [{ def: "X", inc: "Y" }],
+    });
+    const m1 = getNeurodataTypeParentMap(specs);
+    const m2 = getNeurodataTypeParentMap(specs);
+    expect(m1).toBe(m2);
+    expect(m1["X"]).toBe("Y");
+  });
+
+  it("returns the fallback map without specifications", () => {
+    const m = getNeurodataTypeParentMap(undefined);
+    expect(m["GrayscaleImage"]).toBe("Image");
+  });
+});

--- a/src/pages/NwbPage/neurodataTypeInheritance.ts
+++ b/src/pages/NwbPage/neurodataTypeInheritance.ts
@@ -1,0 +1,120 @@
+import {
+  NwbFileSpecifications,
+  SpecificationsDataset,
+  SpecificationsGroup,
+} from "./SpecificationsView/SetupNwbFileSpecificationsProvider";
+
+// Fallback parent relationships for types from the NWB core schema and common
+// extensions. Used when the file's embedded specifications are unavailable or
+// have not loaded yet. Relationships derived from the file's own specifications
+// take precedence over these.
+const fallbackParentMap: { [type: string]: string } = {
+  // static images
+  GrayscaleImage: "Image",
+  RGBImage: "Image",
+  RGBAImage: "Image",
+  // timeseries
+  ImageSeries: "TimeSeries",
+  ImageMaskSeries: "ImageSeries",
+  OpticalSeries: "ImageSeries",
+  TwoPhotonSeries: "ImageSeries",
+  OnePhotonSeries: "ImageSeries",
+  IndexSeries: "TimeSeries",
+  IntervalSeries: "TimeSeries",
+  SpatialSeries: "TimeSeries",
+  ElectricalSeries: "TimeSeries",
+  SpikeEventSeries: "ElectricalSeries",
+  AnnotationSeries: "TimeSeries",
+  AbstractFeatureSeries: "TimeSeries",
+  DecompositionSeries: "TimeSeries",
+  OptogeneticSeries: "TimeSeries",
+  RoiResponseSeries: "TimeSeries",
+  PatchClampSeries: "TimeSeries",
+  CurrentClampSeries: "PatchClampSeries",
+  IZeroClampSeries: "CurrentClampSeries",
+  CurrentClampStimulusSeries: "PatchClampSeries",
+  VoltageClampSeries: "PatchClampSeries",
+  VoltageClampStimulusSeries: "PatchClampSeries",
+  // dynamic tables
+  TimeIntervals: "DynamicTable",
+  Units: "DynamicTable",
+  PlaneSegmentation: "DynamicTable",
+  ElectrodesTable: "DynamicTable",
+  // common extensions
+  LabeledEvents: "Events", // ndx-events
+  PoseEstimationSeries: "SpatialSeries", // ndx-pose
+  FiberPhotometryResponseSeries: "TimeSeries", // ndx-fiber-photometry
+  OptogeneticPulsesTable: "TimeIntervals", // ndx-optogenetics
+};
+
+const parentMapCache = new WeakMap<
+  NwbFileSpecifications,
+  { [type: string]: string }
+>();
+
+// Build a map from neurodata_type_def to neurodata_type_inc, combining the
+// fallback relationships above with the file's embedded specifications (which
+// take precedence and include any extension schemas written into the file).
+export const getNeurodataTypeParentMap = (
+  specifications?: NwbFileSpecifications,
+): { [type: string]: string } => {
+  if (!specifications) return fallbackParentMap;
+  const cached = parentMapCache.get(specifications);
+  if (cached) return cached;
+  const map: { [type: string]: string } = { ...fallbackParentMap };
+  const addEntries = (
+    items: (SpecificationsGroup | SpecificationsDataset)[],
+  ) => {
+    for (const item of items) {
+      if (item.neurodata_type_def && item.neurodata_type_inc) {
+        map[item.neurodata_type_def] = item.neurodata_type_inc;
+      }
+    }
+  };
+  addEntries(specifications.allGroups);
+  addEntries(specifications.allDatasets);
+  parentMapCache.set(specifications, map);
+  return map;
+};
+
+// Return the inheritance chain for a type, starting with the type itself,
+// e.g. ["TwoPhotonSeries", "ImageSeries", "TimeSeries"].
+export const getNeurodataTypeAncestry = (
+  neurodataType: string | undefined,
+  specifications?: NwbFileSpecifications,
+): string[] => {
+  if (!neurodataType) return [];
+  const parentMap = getNeurodataTypeParentMap(specifications);
+  const chain: string[] = [];
+  const visited = new Set<string>();
+  let current: string | undefined = neurodataType;
+  while (current && !visited.has(current)) {
+    chain.push(current);
+    visited.add(current);
+    current = parentMap[current];
+  }
+  return chain;
+};
+
+// Whether neurodataType is baseType or a subtype of baseType, according to the
+// file's specifications (with fallback to known core/extension relationships).
+export const neurodataTypeInheritsFrom = (
+  neurodataType: string | undefined,
+  baseType: string,
+  specifications?: NwbFileSpecifications,
+): boolean => {
+  if (!neurodataType) return false;
+  return getNeurodataTypeAncestry(neurodataType, specifications).includes(
+    baseType,
+  );
+};
+
+export const neurodataTypeInheritsFromAny = (
+  neurodataType: string | undefined,
+  baseTypes: string[],
+  specifications?: NwbFileSpecifications,
+): boolean => {
+  if (!neurodataType) return false;
+  const ancestry = getNeurodataTypeAncestry(neurodataType, specifications);
+  return baseTypes.some((b) => ancestry.includes(b));
+};

--- a/src/pages/NwbPage/plugins/BehavioralEvents/index.ts
+++ b/src/pages/NwbPage/plugins/BehavioralEvents/index.ts
@@ -1,15 +1,22 @@
 import { getHdf5Group } from "@hdf5Interface";
+import { neurodataTypeInheritsFrom } from "../../neurodataTypeInheritance";
 import { NwbObjectViewPlugin } from "../pluginInterface";
 import BehavioralEventsPluginView from "./BehavioralEventsPluginView";
 
 export const behavioralEventsPlugin: NwbObjectViewPlugin = {
   name: "BehavioralEvents",
-  canHandle: async ({ nwbUrl, path }: { nwbUrl: string; path: string }) => {
+  canHandle: async ({ nwbUrl, path, specifications }) => {
     const group = await getHdf5Group(nwbUrl, path);
     if (!group) return false;
 
     // Check if this is a BehavioralEvents neurodata_type
-    if (group.attrs.neurodata_type !== "BehavioralEvents") {
+    if (
+      !neurodataTypeInheritsFrom(
+        group.attrs.neurodata_type,
+        "BehavioralEvents",
+        specifications,
+      )
+    ) {
       return false;
     }
 

--- a/src/pages/NwbPage/plugins/Events/index.ts
+++ b/src/pages/NwbPage/plugins/Events/index.ts
@@ -1,5 +1,6 @@
 import { getHdf5Group } from "@hdf5Interface";
 import { NwbObjectViewPlugin } from "../pluginInterface";
+import { neurodataTypeInheritsFrom } from "../../neurodataTypeInheritance";
 import EventsPluginView from "./EventsPluginView";
 
 export const eventsPlugin: NwbObjectViewPlugin = {
@@ -11,7 +12,14 @@ export const eventsPlugin: NwbObjectViewPlugin = {
     if (o.objectType !== "group") return false;
     const group = await getHdf5Group(o.nwbUrl, o.path);
     if (!group) return false;
-    if (group.attrs.neurodata_type !== "Events") return false;
+    if (
+      !neurodataTypeInheritsFrom(
+        group.attrs.neurodata_type,
+        "Events",
+        o.specifications,
+      )
+    )
+      return false;
     const timestampsDataset = group.datasets.find(
       (ds) => ds.name === "timestamps",
     );

--- a/src/pages/NwbPage/plugins/ExternalFileVideo/index.ts
+++ b/src/pages/NwbPage/plugins/ExternalFileVideo/index.ts
@@ -1,5 +1,6 @@
 import { getHdf5Group } from "@hdf5Interface";
 import { NwbObjectViewPlugin } from "../pluginInterface";
+import { neurodataTypeInheritsFrom } from "../../neurodataTypeInheritance";
 import ExternalFileVideoView from "./ExternalFileVideoView";
 
 export const externalFileVideoPlugin: NwbObjectViewPlugin = {
@@ -9,11 +10,17 @@ export const externalFileVideoPlugin: NwbObjectViewPlugin = {
   label: "Video",
   // Determines whether this plugin can render a given NWB object.
   // Called by findSuitablePlugins() for every object in the hierarchy.
-  canHandle: async ({ nwbUrl, path }: { nwbUrl: string; path: string }) => {
+  canHandle: async ({ nwbUrl, path, specifications }) => {
     const group = await getHdf5Group(nwbUrl, path);
     if (!group) return false;
 
-    if (group.attrs.neurodata_type !== "ImageSeries") {
+    if (
+      !neurodataTypeInheritsFrom(
+        group.attrs.neurodata_type,
+        "ImageSeries",
+        specifications,
+      )
+    ) {
       return false;
     }
 

--- a/src/pages/NwbPage/plugins/Figpack/index.ts
+++ b/src/pages/NwbPage/plugins/Figpack/index.ts
@@ -1,5 +1,6 @@
 import { getHdf5Group } from "@hdf5Interface";
 import { NwbObjectViewPlugin } from "../pluginInterface";
+import { neurodataTypeInheritsFrom } from "../../neurodataTypeInheritance";
 import FigpackRasterPlotView from "./FigpackRasterPlotView";
 import FigpackVideoPreviewView from "./FigpackVideoPreviewView";
 import FigpackPoseEstimationView from "./FigpackPoseEstimationView";
@@ -7,19 +8,18 @@ import FigpackPoseEstimationView from "./FigpackPoseEstimationView";
 export const figpackRasterPlotPlugin: NwbObjectViewPlugin = {
   name: "FigpackRasterPlot",
   label: "Figpack Raster",
-  canHandle: async ({
-    nwbUrl,
-    path,
-    secondaryPaths,
-  }: {
-    nwbUrl: string;
-    path: string;
-    secondaryPaths?: string[];
-  }) => {
+  canHandle: async ({ nwbUrl, path, secondaryPaths, specifications }) => {
     if (secondaryPaths && secondaryPaths.length > 0) return false;
     const group = await getHdf5Group(nwbUrl, path);
     if (!group) return false;
-    if (group.attrs["neurodata_type"] === "Units") return true;
+    if (
+      neurodataTypeInheritsFrom(
+        group.attrs["neurodata_type"],
+        "Units",
+        specifications,
+      )
+    )
+      return true;
     return false;
   },
   component: FigpackRasterPlotView,
@@ -32,24 +32,18 @@ export const figpackRasterPlotPlugin: NwbObjectViewPlugin = {
 export const figpackVideoPreviewPlugin: NwbObjectViewPlugin = {
   name: "FigpackVideoPreview",
   label: "Video Preview",
-  canHandle: async ({
-    nwbUrl,
-    path,
-    secondaryPaths,
-  }: {
-    nwbUrl: string;
-    path: string;
-    secondaryPaths?: string[];
-  }) => {
+  canHandle: async ({ nwbUrl, path, secondaryPaths, specifications }) => {
     if (secondaryPaths && secondaryPaths.length > 0) return false;
     const group = await getHdf5Group(nwbUrl, path);
     if (!group) return false;
-    const supportedTypes = [
-      "ImageSeries",
-      "TwoPhotonSeries",
-      "OnePhotonSeries",
-    ];
-    if (!supportedTypes.includes(group.attrs["neurodata_type"])) return false;
+    if (
+      !neurodataTypeInheritsFrom(
+        group.attrs["neurodata_type"],
+        "ImageSeries",
+        specifications,
+      )
+    )
+      return false;
 
     // Check if data is external (shape contains zeros)
     const dataDataset = group.datasets.find((ds) => ds.name === "data");
@@ -70,19 +64,18 @@ export const figpackVideoPreviewPlugin: NwbObjectViewPlugin = {
 export const FigpackPoseEstimationPlugin: NwbObjectViewPlugin = {
   name: "FigpackPoseEstimation",
   label: "Pose Estimation",
-  canHandle: async ({
-    nwbUrl,
-    path,
-    secondaryPaths,
-  }: {
-    nwbUrl: string;
-    path: string;
-    secondaryPaths?: string[];
-  }) => {
+  canHandle: async ({ nwbUrl, path, secondaryPaths, specifications }) => {
     if (secondaryPaths && secondaryPaths.length > 0) return false;
     const group = await getHdf5Group(nwbUrl, path);
     if (!group) return false;
-    if (group.attrs["neurodata_type"] === "PoseEstimation") return true;
+    if (
+      neurodataTypeInheritsFrom(
+        group.attrs["neurodata_type"],
+        "PoseEstimation",
+        specifications,
+      )
+    )
+      return true;
     return false;
   },
   component: FigpackPoseEstimationView,

--- a/src/pages/NwbPage/plugins/Image/ImagePluginView.tsx
+++ b/src/pages/NwbPage/plugins/Image/ImagePluginView.tsx
@@ -1,4 +1,6 @@
 import { useHdf5Dataset, useHdf5Group } from "@hdf5Interface";
+import { neurodataTypeInheritsFrom } from "../../neurodataTypeInheritance";
+import { useNwbFileSpecifications } from "../../SpecificationsView/SetupNwbFileSpecificationsProvider";
 import ImagesItemView, { ImageItem } from "./ImagesItemView";
 
 type Props = {
@@ -41,11 +43,10 @@ const ImagePluginView: React.FC<Props> = ({
 
 const ImagePluginViewDataset: React.FC<Props> = ({ nwbUrl, path }) => {
   const dataset = useHdf5Dataset(nwbUrl, path);
+  const specifications = useNwbFileSpecifications();
   if (!dataset) return <div>Loading dataset...</div>;
   const neurodataType = dataset.attrs.neurodata_type;
-  if (
-    ["Image", "GrayscaleImage", "RGBImage", "RGBAImage"].includes(neurodataType)
-  ) {
+  if (neurodataTypeInheritsFrom(neurodataType, "Image", specifications)) {
     return (
       <ImageItem nwbUrl={nwbUrl} path={path} neurodataType={neurodataType} />
     );
@@ -61,9 +62,10 @@ const ImagePluginViewGroup: React.FC<Props> = ({
   height,
 }) => {
   const group = useHdf5Group(nwbUrl, path);
+  const specifications = useNwbFileSpecifications();
   if (!group) return <div>Loading group...</div>;
   const neurodataType = group.attrs.neurodata_type;
-  if (["Images"].includes(neurodataType)) {
+  if (neurodataTypeInheritsFrom(neurodataType, "Images", specifications)) {
     return (
       <ImagesItemView
         nwbUrl={nwbUrl}

--- a/src/pages/NwbPage/plugins/Image/ImagesItemView.tsx
+++ b/src/pages/NwbPage/plugins/Image/ImagesItemView.tsx
@@ -7,6 +7,8 @@ import {
   useHdf5Group,
 } from "@hdf5Interface";
 import { DatasetDataType } from "@remote-h5-file";
+import { getNeurodataTypeAncestry } from "../../neurodataTypeInheritance";
+import { useNwbFileSpecifications } from "../../SpecificationsView/SetupNwbFileSpecificationsProvider";
 
 type Props = {
   width: number;
@@ -72,6 +74,8 @@ type ImageItemProps = {
   neurodataType: string;
 };
 
+const coreImageTypes = ["GrayscaleImage", "RGBImage", "RGBAImage", "Image"];
+
 export const ImageItem: FunctionComponent<ImageItemProps> = ({
   nwbUrl,
   path,
@@ -79,22 +83,29 @@ export const ImageItem: FunctionComponent<ImageItemProps> = ({
 }) => {
   const dataset = useHdf5Dataset(nwbUrl, path);
   const { data, errorMessage } = useHdf5DatasetData(nwbUrl, path);
+  const specifications = useNwbFileSpecifications();
+  // Resolve to the nearest core image type in the inheritance chain, so that
+  // extension subtypes (e.g. a type extending RGBImage) get the visualization
+  // of their closest supported ancestor.
+  const resolvedType = useMemo(() => {
+    const ancestry = getNeurodataTypeAncestry(neurodataType, specifications);
+    return ancestry.find((t) => coreImageTypes.includes(t));
+  }, [neurodataType, specifications]);
   if (errorMessage) {
     return <div>Error loading data: {errorMessage}</div>;
   }
   if (!dataset) return <div>Loading dataset...</div>;
   if (!data) return <div>Loading data (ImageItem)...</div>;
 
-  if (neurodataType === "GrayscaleImage") {
+  if (resolvedType === "GrayscaleImage") {
     return <GrayscaleImageItem dataset={dataset} data={data} />;
-  } else if (neurodataType === "Image") {
-    return <RegularImageItem dataset={dataset} data={data} />;
-  } else if (neurodataType === "RGBImage") {
+  } else if (resolvedType === "RGBImage") {
     return <RGBImageItem dataset={dataset} data={data} />;
-  } else if (neurodataType === "RGBAImage") {
+  } else if (resolvedType === "RGBAImage") {
     return <RGBAImageItem dataset={dataset} data={data} />;
   } else {
-    return <div>Unexpected neurodata_type: {neurodataType}</div>;
+    // "Image" or unknown: infer from the dataset shape
+    return <RegularImageItem dataset={dataset} data={data} />;
   }
 };
 
@@ -186,6 +197,9 @@ const RegularImageItem: FunctionComponent<RegularImageItemProps> = ({
   } else if (dataset.shape.length === 3 && dataset.shape[2] === 3) {
     // I guess this is an RGB image
     return <RGBImageItem dataset={dataset} data={data} />;
+  } else if (dataset.shape.length === 3 && dataset.shape[2] === 4) {
+    // I guess this is an RGBA image
+    return <RGBAImageItem dataset={dataset} data={data} />;
   } else {
     return (
       <div>Image not supported with shape: {dataset.shape.join(", ")}</div>

--- a/src/pages/NwbPage/plugins/Image/index.ts
+++ b/src/pages/NwbPage/plugins/Image/index.ts
@@ -1,25 +1,32 @@
 import { getHdf5Dataset, getHdf5Group } from "@hdf5Interface";
+import { neurodataTypeInheritsFrom } from "../../neurodataTypeInheritance";
 import { NwbObjectViewPlugin } from "../pluginInterface";
 import ImagePluginView from "./ImagePluginView";
 
 export const imagePlugin: NwbObjectViewPlugin = {
   name: "Image",
-  canHandle: async ({
-    nwbUrl,
-    path,
-    objectType,
-  }: {
-    nwbUrl: string;
-    path: string;
-    objectType: "group" | "dataset";
-  }) => {
+  canHandle: async ({ nwbUrl, path, objectType, specifications }) => {
     if (objectType === "dataset") {
       const ds = await getHdf5Dataset(nwbUrl, path);
-      if (ds?.attrs.neurodata_type === "Image") return true;
+      if (
+        neurodataTypeInheritsFrom(
+          ds?.attrs.neurodata_type,
+          "Image",
+          specifications,
+        )
+      )
+        return true;
     } else {
       // objectType === "group"
       const grp = await getHdf5Group(nwbUrl, path);
-      if (grp?.attrs.neurodata_type === "Images") return true;
+      if (
+        neurodataTypeInheritsFrom(
+          grp?.attrs.neurodata_type,
+          "Images",
+          specifications,
+        )
+      )
+        return true;
     }
     return false;
   },
@@ -37,6 +44,9 @@ http://neurosift.app/nwb?url=https://api.dandiarchive.org/api/assets/f02db27e-82
 
 Images:
 https://neurosift.app/nwb?url=https://api.dandiarchive.org/api/assets/65a7e913-45c7-48db-bf19-b9f5e910110a/download/&dandisetId=000673&dandisetVersion=0.250122.0110&tab=/stimulus/presentation/StimulusPresentation/indexed_images
+
+GrayscaleImage:
+https://neurosift.app/nwb?url=https://api.dandiarchive.org/api/assets/ba9fa55d-6b94-46cf-b72f-6135e92e8f45/download/&dandisetId=001780&dandisetVersion=draft&tab=/processing/plane-1/images/correlation_projection_denoised_plane-1
 
 */
 

--- a/src/pages/NwbPage/plugins/ImageSegmentation/ImageSegmentationItemView/PlaneSegmentationView.tsx
+++ b/src/pages/NwbPage/plugins/ImageSegmentation/ImageSegmentationItemView/PlaneSegmentationView.tsx
@@ -10,6 +10,7 @@ import {
   Hdf5Dataset,
   Hdf5Group,
 } from "@hdf5Interface";
+import { neurodataTypeInheritsFrom } from "../../../neurodataTypeInheritance";
 
 type Props = {
   width: number;
@@ -164,7 +165,13 @@ const determineImageSizeFromNwbFileContext = async (
   let parentGroup = await getHdf5Group(nwbUrl, parentPath);
   if (!parentGroup)
     throw Error(`Unable to get parent group for determining image size`);
-  if (parentGroup.attrs["neurodata_type"] === "ImageSegmentation") {
+  // No specifications available in this helper; falls back to core relationships
+  if (
+    neurodataTypeInheritsFrom(
+      parentGroup.attrs["neurodata_type"],
+      "ImageSegmentation",
+    )
+  ) {
     // need to go up one more level
     parentPath = parentPath.split("/").slice(0, -1).join("/");
     parentGroup = await getHdf5Group(nwbUrl, parentPath);
@@ -172,7 +179,7 @@ const determineImageSizeFromNwbFileContext = async (
       throw Error(`Unable to get parent group for determining image size`);
   }
   for (const sg of parentGroup.subgroups) {
-    if (sg.attrs["neurodata_type"] === "Images") {
+    if (neurodataTypeInheritsFrom(sg.attrs["neurodata_type"], "Images")) {
       const imagesGroup = await getHdf5Group(
         nwbUrl,
         `${parentPath}/${sg.name}`,
@@ -181,10 +188,7 @@ const determineImageSizeFromNwbFileContext = async (
         continue;
       }
       for (const ds of imagesGroup.datasets) {
-        if (
-          ds.attrs["neurodata_type"] === "Image" ||
-          ds.attrs["neurodata_type"] === "GrayscaleImage"
-        ) {
+        if (neurodataTypeInheritsFrom(ds.attrs["neurodata_type"], "Image")) {
           if (ds.shape.length === 2) {
             return ds.shape;
           }

--- a/src/pages/NwbPage/plugins/ImageSegmentation/index.ts
+++ b/src/pages/NwbPage/plugins/ImageSegmentation/index.ts
@@ -1,17 +1,25 @@
 import { getHdf5Group } from "@hdf5Interface";
 import { NwbObjectViewPlugin } from "../pluginInterface";
+import { neurodataTypeInheritsFrom } from "../../neurodataTypeInheritance";
 import ImageSegmentationPluginView, {
   PlaneSegmentationPluginView,
 } from "./ImageSegmentationPluginView";
 
 export const imageSegmentationPlugin: NwbObjectViewPlugin = {
   name: "ImageSegmentation",
-  canHandle: async ({ nwbUrl, path }: { nwbUrl: string; path: string }) => {
+  canHandle: async ({ nwbUrl, path, specifications }) => {
     const group = await getHdf5Group(nwbUrl, path);
     if (!group) return false;
 
     // Check if this is an ImageSegmentation neurodata_type
-    if (group.attrs.neurodata_type !== "ImageSegmentation") return false;
+    if (
+      !neurodataTypeInheritsFrom(
+        group.attrs.neurodata_type,
+        "ImageSegmentation",
+        specifications,
+      )
+    )
+      return false;
 
     // Check if we have any subgroups (plane segmentations)
     return group.subgroups.length > 0;
@@ -24,19 +32,33 @@ export const imageSegmentationPlugin: NwbObjectViewPlugin = {
 
 export const planeSegmentationPlugin: NwbObjectViewPlugin = {
   name: "PlaneSegmentation",
-  canHandle: async ({ nwbUrl, path }: { nwbUrl: string; path: string }) => {
+  canHandle: async ({ nwbUrl, path, specifications }) => {
     const group = await getHdf5Group(nwbUrl, path);
     if (!group) return false;
 
     // Check if this is an PlaneSegmentation neurodata_type
-    if (group.attrs.neurodata_type !== "PlaneSegmentation") return false;
+    if (
+      !neurodataTypeInheritsFrom(
+        group.attrs.neurodata_type,
+        "PlaneSegmentation",
+        specifications,
+      )
+    )
+      return false;
 
     // Check if this is a subgroup of an ImageSegmentation
     const parentPath = path.split("/").slice(0, -1).join("/");
     const parentGroup = await getHdf5Group(nwbUrl, parentPath);
     if (!parentGroup) return false;
     // Check if the parent group is an ImageSegmentation
-    if (parentGroup.attrs.neurodata_type !== "ImageSegmentation") return false;
+    if (
+      !neurodataTypeInheritsFrom(
+        parentGroup.attrs.neurodata_type,
+        "ImageSegmentation",
+        specifications,
+      )
+    )
+      return false;
 
     return true;
   },

--- a/src/pages/NwbPage/plugins/ImageSeriesMp4/index.ts
+++ b/src/pages/NwbPage/plugins/ImageSeriesMp4/index.ts
@@ -1,18 +1,22 @@
 import { getHdf5Group } from "@hdf5Interface";
 import { NwbObjectViewPlugin } from "../pluginInterface";
+import { neurodataTypeInheritsFromAny } from "../../neurodataTypeInheritance";
 import ImageSeriesMp4View from "./ImageSeriesMp4View";
 
 export const imageSeriesMp4Plugin: NwbObjectViewPlugin = {
   name: "ImageSeriesMp4",
   label: "MP4 Video",
-  canHandle: async ({ nwbUrl, path }: { nwbUrl: string; path: string }) => {
+  canHandle: async ({ nwbUrl, path, specifications }) => {
     const group = await getHdf5Group(nwbUrl, path);
     if (!group) return false;
 
     // Check if this is a TwoPhotonSeries or OnePhotonSeries neurodata_type
     if (
-      group.attrs.neurodata_type !== "TwoPhotonSeries" &&
-      group.attrs.neurodata_type !== "OnePhotonSeries"
+      !neurodataTypeInheritsFromAny(
+        group.attrs.neurodata_type,
+        ["TwoPhotonSeries", "OnePhotonSeries"],
+        specifications,
+      )
     ) {
       return false;
     }

--- a/src/pages/NwbPage/plugins/IntervalSeries/index.ts
+++ b/src/pages/NwbPage/plugins/IntervalSeries/index.ts
@@ -1,5 +1,6 @@
 import { getHdf5Group } from "@hdf5Interface";
 import { NwbObjectViewPlugin } from "../pluginInterface";
+import { neurodataTypeInheritsFrom } from "../../neurodataTypeInheritance";
 import IntervalSeriesPluginView from "./IntervalSeriesPluginView";
 
 export const intervalSeriesPlugin: NwbObjectViewPlugin = {
@@ -11,7 +12,14 @@ export const intervalSeriesPlugin: NwbObjectViewPlugin = {
     if (o.objectType !== "group") return false;
     const group = await getHdf5Group(o.nwbUrl, o.path);
     if (!group) return false;
-    if (group.attrs.neurodata_type !== "IntervalSeries") return false;
+    if (
+      !neurodataTypeInheritsFrom(
+        group.attrs.neurodata_type,
+        "IntervalSeries",
+        o.specifications,
+      )
+    )
+      return false;
     return true; // The actual check will happen in the view component
   },
   showInMultiView: true,

--- a/src/pages/NwbPage/plugins/PSTH/index.ts
+++ b/src/pages/NwbPage/plugins/PSTH/index.ts
@@ -1,27 +1,34 @@
 import { getHdf5Group } from "@hdf5Interface";
 import { NwbObjectViewPlugin } from "../pluginInterface";
+import { neurodataTypeInheritsFrom } from "../../neurodataTypeInheritance";
 import PSTHView from "./PSTHView";
 
 export const psthPlugin: NwbObjectViewPlugin = {
   name: "PSTH",
-  canHandle: async ({
-    nwbUrl,
-    path,
-    secondaryPaths,
-  }: {
-    nwbUrl: string;
-    path: string;
-    secondaryPaths?: string[];
-  }) => {
+  canHandle: async ({ nwbUrl, path, secondaryPaths, specifications }) => {
     if (!secondaryPaths) return false;
     if (secondaryPaths.length !== 1) return false;
     const group = await getHdf5Group(nwbUrl, path);
     if (!group) return false;
-    if (group.attrs["neurodata_type"] !== "TimeIntervals") return false;
+    if (
+      !neurodataTypeInheritsFrom(
+        group.attrs["neurodata_type"],
+        "TimeIntervals",
+        specifications,
+      )
+    )
+      return false;
     const unitsPath = secondaryPaths[0];
     const unitsGroup = await getHdf5Group(nwbUrl, unitsPath);
     if (!unitsGroup) return false;
-    if (unitsGroup.attrs["neurodata_type"] !== "Units") return false;
+    if (
+      !neurodataTypeInheritsFrom(
+        unitsGroup.attrs["neurodata_type"],
+        "Units",
+        specifications,
+      )
+    )
+      return false;
     return true;
   },
   component: PSTHView,

--- a/src/pages/NwbPage/plugins/PoseEstimation/index.ts
+++ b/src/pages/NwbPage/plugins/PoseEstimation/index.ts
@@ -1,5 +1,6 @@
 import { getHdf5Group } from "@hdf5Interface";
 import { NwbObjectViewPlugin } from "../pluginInterface";
+import { neurodataTypeInheritsFrom } from "../../neurodataTypeInheritance";
 import PoseEstimationView from "./PoseEstimationView";
 
 export const poseEstimationPlugin: NwbObjectViewPlugin = {
@@ -7,12 +8,23 @@ export const poseEstimationPlugin: NwbObjectViewPlugin = {
   label: "Pose overlay",
   // Activates on an ndx-pose PoseEstimation container that holds at least one
   // PoseEstimationSeries.
-  canHandle: async ({ nwbUrl, path }: { nwbUrl: string; path: string }) => {
+  canHandle: async ({ nwbUrl, path, specifications }) => {
     const group = await getHdf5Group(nwbUrl, path);
     if (!group) return false;
-    if (group.attrs?.neurodata_type !== "PoseEstimation") return false;
-    return group.subgroups.some(
-      (sg) => sg.attrs?.neurodata_type === "PoseEstimationSeries",
+    if (
+      !neurodataTypeInheritsFrom(
+        group.attrs?.neurodata_type,
+        "PoseEstimation",
+        specifications,
+      )
+    )
+      return false;
+    return group.subgroups.some((sg) =>
+      neurodataTypeInheritsFrom(
+        sg.attrs?.neurodata_type,
+        "PoseEstimationSeries",
+        specifications,
+      ),
     );
   },
   component: PoseEstimationView,

--- a/src/pages/NwbPage/plugins/PythonScript/LoadInPythonComponent.tsx
+++ b/src/pages/NwbPage/plugins/PythonScript/LoadInPythonComponent.tsx
@@ -8,6 +8,8 @@ import {
   getCustomPythonCodeForTimeSeries,
   getCustomPythonCodeForUnits,
 } from "./customPythonCode";
+import { neurodataTypeInheritsFrom } from "../../neurodataTypeInheritance";
+import { useNwbFileSpecifications } from "../../SpecificationsView/SetupNwbFileSpecificationsProvider";
 
 type Props = {
   nwbUrl: string;
@@ -16,19 +18,21 @@ type Props = {
 
 const LoadInPythonWindow: FunctionComponent<Props> = ({ nwbUrl, path }) => {
   const group = useHdf5Group(nwbUrl, path);
+  const specifications = useNwbFileSpecifications();
 
   const customCode = useMemo(() => {
     if (!group) return "";
+    const nt = group.attrs.neurodata_type;
     if (isTimeSeriesGroup(group)) {
       return getCustomPythonCodeForTimeSeries(group);
-    } else if (group.attrs.neurodata_type === "TimeIntervals") {
+    } else if (neurodataTypeInheritsFrom(nt, "TimeIntervals", specifications)) {
       return getCustomPythonCodeForTimeIntervals(group);
-    } else if (group.attrs.neurodata_type === "Units") {
+    } else if (neurodataTypeInheritsFrom(nt, "Units", specifications)) {
       return getCustomPythonCodeForUnits(group);
     } else {
       return "";
     }
-  }, [group]);
+  }, [group, specifications]);
 
   const source: string = useMemo(() => {
     if (!group) return "";

--- a/src/pages/NwbPage/plugins/Raster/index.ts
+++ b/src/pages/NwbPage/plugins/Raster/index.ts
@@ -1,22 +1,22 @@
 import { getHdf5Group } from "@hdf5Interface";
 import { NwbObjectViewPlugin } from "../pluginInterface";
+import { neurodataTypeInheritsFrom } from "../../neurodataTypeInheritance";
 import RasterView from "./RasterView";
 
 export const rasterPlugin: NwbObjectViewPlugin = {
   name: "Raster",
-  canHandle: async ({
-    nwbUrl,
-    path,
-    secondaryPaths,
-  }: {
-    nwbUrl: string;
-    path: string;
-    secondaryPaths?: string[];
-  }) => {
+  canHandle: async ({ nwbUrl, path, secondaryPaths, specifications }) => {
     if (secondaryPaths && secondaryPaths.length > 0) return false;
     const group = await getHdf5Group(nwbUrl, path);
     if (!group) return false;
-    if (group.attrs["neurodata_type"] === "Units") return true;
+    if (
+      neurodataTypeInheritsFrom(
+        group.attrs["neurodata_type"],
+        "Units",
+        specifications,
+      )
+    )
+      return true;
     return false;
   },
   component: RasterView,

--- a/src/pages/NwbPage/plugins/SpatialSeries/index.ts
+++ b/src/pages/NwbPage/plugins/SpatialSeries/index.ts
@@ -1,34 +1,23 @@
 import { getHdf5Group } from "@hdf5Interface";
+import { neurodataTypeInheritsFrom } from "../../neurodataTypeInheritance";
 import { NwbObjectViewPlugin } from "../pluginInterface";
 import SpatialSeriesPluginView from "./SpatialSeriesPluginView";
-import { NwbFileSpecifications } from "../../SpecificationsView/SetupNwbFileSpecificationsProvider";
 
 export const spatialSeriesPlugin: NwbObjectViewPlugin = {
   name: "SpatialSeriesXY",
   label: "XY",
-  canHandle: async ({
-    nwbUrl,
-    path,
-    specifications,
-  }: {
-    nwbUrl: string;
-    path: string;
-    specifications?: NwbFileSpecifications;
-  }) => {
+  canHandle: async ({ nwbUrl, path, specifications }) => {
     const group = await getHdf5Group(nwbUrl, path);
     if (!group) return false;
 
-    const spatialSeriesTypes: string[] = ["SpatialSeries"];
-    if (specifications) {
-      for (const a of specifications.allGroups) {
-        if (a.neurodata_type_inc === "SpatialSeries") {
-          spatialSeriesTypes.push(a.neurodata_type_def);
-        }
-      }
-    }
-
-    // Check if this is a SpatialSeries or PoseEstimationSeries neurodata_type
-    if (!spatialSeriesTypes.includes(group.attrs.neurodata_type)) {
+    // Check if this is a SpatialSeries (or a subtype, e.g. PoseEstimationSeries)
+    if (
+      !neurodataTypeInheritsFrom(
+        group.attrs.neurodata_type,
+        "SpatialSeries",
+        specifications,
+      )
+    ) {
       return false;
     }
 

--- a/src/pages/NwbPage/plugins/SpikeDensity/index.ts
+++ b/src/pages/NwbPage/plugins/SpikeDensity/index.ts
@@ -1,22 +1,22 @@
 import { getHdf5Group } from "@hdf5Interface";
 import { NwbObjectViewPlugin } from "../pluginInterface";
+import { neurodataTypeInheritsFrom } from "../../neurodataTypeInheritance";
 import SpikeDensityView from "./SpikeDensityView";
 
 export const spikeDensityPlugin: NwbObjectViewPlugin = {
   name: "SpikeDensity",
-  canHandle: async ({
-    nwbUrl,
-    path,
-    secondaryPaths,
-  }: {
-    nwbUrl: string;
-    path: string;
-    secondaryPaths?: string[];
-  }) => {
+  canHandle: async ({ nwbUrl, path, secondaryPaths, specifications }) => {
     if (secondaryPaths && secondaryPaths.length > 0) return false;
     const group = await getHdf5Group(nwbUrl, path);
     if (!group) return false;
-    if (group.attrs["neurodata_type"] === "Units") return true;
+    if (
+      neurodataTypeInheritsFrom(
+        group.attrs["neurodata_type"],
+        "Units",
+        specifications,
+      )
+    )
+      return true;
     return false;
   },
   component: SpikeDensityView,

--- a/src/pages/NwbPage/plugins/TimeIntervals/index.ts
+++ b/src/pages/NwbPage/plugins/TimeIntervals/index.ts
@@ -1,20 +1,18 @@
 import { getHdf5Group } from "@hdf5Interface";
 import { NwbObjectViewPlugin } from "../pluginInterface";
+import { neurodataTypeInheritsFrom } from "../../neurodataTypeInheritance";
 import TimeIntervalsPluginView from "./TimeIntervalsPluginView";
 
 export const timeIntervalsPlugin: NwbObjectViewPlugin = {
   name: "TimeIntervals",
-  canHandle: async ({ nwbUrl, path }: { nwbUrl: string; path: string }) => {
+  canHandle: async ({ nwbUrl, path, specifications }) => {
     const group = await getHdf5Group(nwbUrl, path);
     if (!group) return false;
 
     // Check if this is a TimeIntervals neurodata type
     const nt = group.attrs?.neurodata_type;
-    const isTimeIntervals = [
-      "TimeIntervals",
-      "OptogeneticPulsesTable",
-    ].includes(nt);
-    if (!isTimeIntervals) return false;
+    if (!neurodataTypeInheritsFrom(nt, "TimeIntervals", specifications))
+      return false;
 
     // Check for required datasets
     const hasStartTime = group.datasets.some((ds) => ds.name === "start_time");

--- a/src/pages/NwbPage/plugins/TrialAlignedSeries/index.ts
+++ b/src/pages/NwbPage/plugins/TrialAlignedSeries/index.ts
@@ -1,33 +1,40 @@
 import { getHdf5Group } from "@hdf5Interface";
 import { NwbObjectViewPlugin } from "../pluginInterface";
+import {
+  neurodataTypeInheritsFrom,
+  neurodataTypeInheritsFromAny,
+} from "../../neurodataTypeInheritance";
 import TrialAlignedPluginView from "./TrialAlignedPluginView";
 
 export const trialAlignedSeriesPlugin: NwbObjectViewPlugin = {
   name: "TrialAlignedSeries",
-  canHandle: async ({
-    nwbUrl,
-    path,
-    secondaryPaths,
-  }: {
-    nwbUrl: string;
-    path: string;
-    secondaryPaths?: string[];
-  }) => {
+  canHandle: async ({ nwbUrl, path, secondaryPaths, specifications }) => {
     if (!secondaryPaths) return false;
     if (secondaryPaths.length !== 1) return false;
     const group = await getHdf5Group(nwbUrl, path);
     if (!group) return false;
-    if (group.attrs["neurodata_type"] !== "TimeIntervals") return false;
+    if (
+      !neurodataTypeInheritsFrom(
+        group.attrs["neurodata_type"],
+        "TimeIntervals",
+        specifications,
+      )
+    )
+      return false;
 
     const secondaryPath = secondaryPaths[0];
     const secondaryGroup = await getHdf5Group(nwbUrl, secondaryPath);
     if (!secondaryGroup) return false;
     if (
-      ![
-        "RoiResponseSeries",
-        "FiberPhotometryResponseSeries",
-        "MicroscopyResponseSeries",
-      ].includes(secondaryGroup.attrs["neurodata_type"])
+      !neurodataTypeInheritsFromAny(
+        secondaryGroup.attrs["neurodata_type"],
+        [
+          "RoiResponseSeries",
+          "FiberPhotometryResponseSeries",
+          "MicroscopyResponseSeries",
+        ],
+        specifications,
+      )
     )
       return false;
     return true;

--- a/src/pages/NwbPage/plugins/TwoPhotonSeries/index.ts
+++ b/src/pages/NwbPage/plugins/TwoPhotonSeries/index.ts
@@ -1,18 +1,22 @@
 import { getHdf5Group } from "@hdf5Interface";
 import { NwbObjectViewPlugin } from "../pluginInterface";
+import { neurodataTypeInheritsFrom } from "../../neurodataTypeInheritance";
 import TwoPhotonSeriesPluginView from "./TwoPhotonSeriesPluginView";
 
 export const twoPhotonSeriesPlugin: NwbObjectViewPlugin = {
   name: "TwoPhotonSeries",
-  canHandle: async ({ nwbUrl, path }: { nwbUrl: string; path: string }) => {
+  canHandle: async ({ nwbUrl, path, specifications }) => {
     const group = await getHdf5Group(nwbUrl, path);
     if (!group) return false;
 
-    // Check if this is a TwoPhotonSeries or OnePhotonSeries neurodata_type
+    // Check if this is an ImageSeries neurodata_type (which includes
+    // TwoPhotonSeries and OnePhotonSeries)
     if (
-      group.attrs.neurodata_type !== "TwoPhotonSeries" &&
-      group.attrs.neurodata_type !== "OnePhotonSeries" &&
-      group.attrs.neurodata_type !== "ImageSeries"
+      !neurodataTypeInheritsFrom(
+        group.attrs.neurodata_type,
+        "ImageSeries",
+        specifications,
+      )
     ) {
       return false;
     }

--- a/src/pages/NwbPage/plugins/simple-timeseries/index.ts
+++ b/src/pages/NwbPage/plugins/simple-timeseries/index.ts
@@ -1,10 +1,11 @@
 import { getHdf5Group } from "@hdf5Interface";
 import { NwbObjectViewPlugin } from "../pluginInterface";
+import { neurodataTypeInheritsFrom } from "../../neurodataTypeInheritance";
 import { SimpleTimeseriesView } from "./SimpleTimeseriesView";
 
 export const simpleTimeseriesPlugin: NwbObjectViewPlugin = {
   name: "SimpleTimeseries",
-  canHandle: async ({ nwbUrl, path }: { nwbUrl: string; path: string }) => {
+  canHandle: async ({ nwbUrl, path, specifications }) => {
     const group = await getHdf5Group(nwbUrl, path);
     if (!group) return false;
 
@@ -13,8 +14,11 @@ export const simpleTimeseriesPlugin: NwbObjectViewPlugin = {
     if (!dataDataset) return false;
 
     // Check if this is a LabeledEvents neurodata type
-    const isLabeledEvents =
-      dataDataset.attrs?.neurodata_type === "LabeledEvents";
+    const isLabeledEvents = neurodataTypeInheritsFrom(
+      dataDataset.attrs?.neurodata_type,
+      "LabeledEvents",
+      specifications,
+    );
 
     // For LabeledEvents, require timestamps and labels
     if (isLabeledEvents) {

--- a/src/pages/NwbPage/useNeurodataObjects.ts
+++ b/src/pages/NwbPage/useNeurodataObjects.ts
@@ -110,7 +110,7 @@ export const useNeurodataObjects = (nwbUrl: string) => {
         const node = queue.shift();
         if (!node) continue;
         const group = node.group;
-        let subgroups = group.subgroups.slice(0, 200);
+        const subgroups = group.subgroups.slice(0, 200);
         if (subgroups.length < group.subgroups.length) {
           partialLoad = true;
         }


### PR DESCRIPTION
Closes #439

## Background

Visualization matching throughout the app compared the `neurodata_type` attribute against literal type names. Since NWB files store only the most specific type on each object, subtypes were not recognized by views registered for their parent types. The example from #439 is a `GrayscaleImage` dataset that did not get the image visualization when opened directly, even though the rendering code for it already existed.

## Approach

A new shared utility (`src/pages/NwbPage/neurodataTypeInheritance.ts`) builds a parent map from the file's embedded `/specifications` group (covering extension schemas written into the file) and walks the inheritance chain from the object's type upward. A hardcoded fallback map of known core and common extension relationships is used when specifications are unavailable or have not loaded yet; relationships from the file's own specifications take precedence.

Matching semantics:

- Plugin `canHandle` checks match if the plugin's target type appears anywhere in the object's inheritance chain, so a plugin registered for `Image` accepts any descendant of `Image`.
- Sites that must choose a single renderer (for example the image renderer choosing among `GrayscaleImage`, `RGBImage`, `RGBAImage`, and `Image`) resolve to the nearest supported ancestor, so the most specific available visualization wins.

## Changes

- All plugin `canHandle` checks converted to inheritance matching (BehavioralEvents, Events, ExternalFileVideo, Figpack, Image, ImageSegmentation, ImageSeriesMp4, IntervalSeries, PSTH, PoseEstimation, Raster, SpatialSeries, SpikeDensity, TimeIntervals, TrialAlignedSeries, TwoPhotonSeries, simple-timeseries). The SpatialSeries plugin's one-level specification walk and the TimeseriesAlignmentView's local `descendsFrom` implementation are replaced by the shared utility, which resolves transitively.
- Non-plugin dispatch sites updated: the image renderer, hierarchy view (Units default marker), main workspace (default units detection), multi-video discovery, external video detection, Python usage script generation, and the load-in-Python code snippets.
- `specifications` added to the dependency arrays of the plugin-matching effects in `NwbObjectView` and `NwbHierarchyView`, so matching re-runs once specifications finish loading instead of silently degrading to exact-string comparison.
- The shape-based fallback image renderer now also handles 4-channel (RGBA) data.
- Adds vitest with unit tests for the utility (`npm test`): transitive resolution, fallback behavior, spec precedence, cycle protection, and lowest-ancestor resolution.
- Fixes the codespell skip pattern so the root `package-lock.json` is actually skipped, and a pre-existing `prefer-const` lint error in `useNeurodataObjects.ts`.

## Testing

- `npm test`: 17 tests pass.
- `npx tsc --noEmit` and `eslint src/pages/NwbPage` are clean.
- Verified in the browser against DANDI assets: the GrayscaleImage example from #439 now renders with brightness/contrast controls; the Image example (000728) and the Images group with RGB images (000673) still render; the 000673 hierarchy still shows Units (default), Raster, and PSTH buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)