### PR TITLE
Show scalar dataset values inline in the default tree view

### DIFF
--- a/src/pages/NwbPage/plugins/default/DefaultView.tsx
+++ b/src/pages/NwbPage/plugins/default/DefaultView.tsx
@@ -27,6 +27,22 @@ const product = (shape: number[]): number => {
   return shape.reduce((acc, val) => acc * val, 1);
 };
 
+const formatScalarValue = (data: DatasetDataType | null): string => {
+  if (data === null || data === undefined) return "";
+  // Single-element datasets (shape [1]) come back as a one-element array
+  let value: unknown = data;
+  if (
+    (Array.isArray(value) || ArrayBuffer.isView(value)) &&
+    (value as { length: number }).length === 1
+  ) {
+    value = (value as unknown[])[0];
+  }
+  if (typeof value === "object") {
+    return JSON.stringify(value);
+  }
+  return String(value);
+};
+
 const TreeNode: React.FC<TreeNodeProps> = ({
   name,
   path,
@@ -40,6 +56,12 @@ const TreeNode: React.FC<TreeNodeProps> = ({
   const group = useHdf5Group(nwbUrl, type === "group" ? path : "");
   const dataset = useHdf5Dataset(nwbUrl, type === "dataset" ? path : "");
 
+  // Scalar and single-element datasets (e.g. the fields of /general/subject,
+  // which may be stored with shape [] or [1]) show their value inline next to
+  // the name rather than hiding it under the accordion
+  const isScalar =
+    type === "dataset" && !!dataset && product(dataset.shape) === 1;
+
   const viewDatasetInConsole = useCallback(async () => {
     if (type === "dataset" && dataset) {
       console.info("Loading dataset data for " + path);
@@ -51,7 +73,12 @@ const TreeNode: React.FC<TreeNodeProps> = ({
 
   useEffect(() => {
     const loadDatasetInfo = async () => {
-      if (type === "dataset" && expanded && dataset && !datasetInfo) {
+      if (
+        type === "dataset" &&
+        (expanded || isScalar) &&
+        dataset &&
+        !datasetInfo
+      ) {
         if (product(dataset.shape) <= 100) {
           try {
             const data = await getHdf5DatasetData(nwbUrl, path, {});
@@ -69,7 +96,7 @@ const TreeNode: React.FC<TreeNodeProps> = ({
       }
     };
     loadDatasetInfo();
-  }, [type, expanded, dataset, datasetInfo, nwbUrl, path]);
+  }, [type, expanded, isScalar, dataset, datasetInfo, nwbUrl, path]);
 
   const handleClick = () => {
     setExpanded(!expanded);
@@ -88,7 +115,12 @@ const TreeNode: React.FC<TreeNodeProps> = ({
       >
         <span style={{ marginRight: "5px" }}>{expanded ? "▼" : "►"}</span>
         {name}
-        {type === "dataset" && dataset && !expanded && (
+        {isScalar && (
+          <span style={{ color: "#333", marginLeft: "5px" }}>
+            : {formatScalarValue(datasetInfo?.data ?? null)}
+          </span>
+        )}
+        {type === "dataset" && dataset && !expanded && !isScalar && (
           <span
             style={{ color: "#666", marginLeft: "10px", fontSize: "0.9em" }}
           >
@@ -144,7 +176,8 @@ const TreeNode: React.FC<TreeNodeProps> = ({
                 )}
               </div>
               <div>
-                {datasetInfo?.data !== undefined && (
+                {/* For scalars the value is already shown inline next to the name */}
+                {!isScalar && datasetInfo?.data !== undefined && (
                   <div>VALUE: {JSON.stringify(datasetInfo.data, null, 2)}</div>
                 )}
               </div>


### PR DESCRIPTION
For groups rendered by the default tree view, scalar and single-element datasets (for example the fields of `/general/subject`, which are stored with shape `[]` or `[1]`) previously showed only their dtype and shape, with the value hidden behind the accordion.

These values are now loaded eagerly and rendered inline next to the dataset name, so a subject group reads as `sex : F`, `species : Mus musculus`, and so on. The accordion still expands to show dtype, shape, and attributes, and the inline value is not repeated in the expanded details.

Example (from the report): https://neurosift.app/nwb?url=https%3A%2F%2Fapi.dandiarchive.org%2Fapi%2Fassets%2Ff24e825f-f5b1-4287-a004-7ac3a20c107d%2Fdownload%2F&dandisetId=000409&dandisetVersion=0.260309.1324&tab=%2Fgeneral%2Fsubject

Verified in the browser against that asset: all eight subject fields render their values inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)