### PR TITLE
Label boolean and bigint group values in the PSTH legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## August 5, 2026
+
+- PSTH group legend now labels boolean and bigint group values instead of showing "?"
+
 ## March 13, 2026
 
 - Show dataset chunking and compression in HDF5 view

--- a/src/pages/NwbPage/plugins/PSTH/PSTHItemView/PSTHUnitWidget.tsx
+++ b/src/pages/NwbPage/plugins/PSTH/PSTHItemView/PSTHUnitWidget.tsx
@@ -613,17 +613,23 @@ type GroupLabelProps = {
 
 const GroupLabel: FunctionComponent<GroupLabelProps> = ({ group }) => {
   if (!group) return <></>;
-  else if (typeof group.group === "number") {
-    return <>{group.group}</>;
-  } else if (typeof group.group === "string") {
-    return <>{group.group}</>;
-  } else if (typeof group.group === "object") {
-    if (group.group._REFERENCE) {
+  const value = group.group;
+  if (typeof value === "number" || typeof value === "string") {
+    return <>{value}</>;
+  } else if (typeof value === "boolean" || typeof value === "bigint") {
+    // A boolean trials column (e.g. "rewarded") comes back as JS booleans, and a
+    // 64-bit integer column can come back as bigints. React renders neither of
+    // those directly, so they have to be stringified. Without this the legend
+    // fell through to the "?" case below.
+    return <>{value.toString()}</>;
+  } else if (value && typeof value === "object") {
+    if (value._REFERENCE) {
       return <>_REF</>;
     } else {
       return <>_OBJ</>;
     }
   } else {
+    // null / undefined / anything else we have no sensible label for
     return <>?</>;
   }
 };


### PR DESCRIPTION
Fixes #335.

This is @adityasingh2400's contribution from #436, pushed to an in-repo branch so that the preview deployment can run. Preview deploys do not work for fork PRs because GitHub withholds repository secrets from pull_request-triggered runs of fork code, so the Cloudflare deploy silently does nothing there. The commit is carried over unchanged (18d7258), so authorship and contribution credit remain with Aditya. Please merge with a merge commit or rebase rather than squash, since a squash commit would be attributed to the PR opener.

Original description from #436:

> `GroupLabel` in `PSTHUnitWidget.tsx` branches on `typeof` for `number`, `string` and `object`, and falls through to a literal `?` for anything else. A boolean trials column such as `rewarded` arrives as JS booleans, so it hit the fallback. That is consistent with the report: the group selectors below the plot are built from `x.toString()` and showed `true` and `false` correctly, while the legend showed `?`. React does not render a raw boolean either, so the value has to be stringified.
>
> This handles `boolean` and `bigint` explicitly. It also guards the object branch against `null`, which previously threw a `TypeError` reading `_REFERENCE` off it, since `typeof null === "object"`.

See #436 for the full writeup and before/after rendering table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)