### PR TITLE
Split preview deploy into secretless build plus workflow_run deploy

### DIFF
--- a/.github/workflows/preview-build.yml
+++ b/.github/workflows/preview-build.yml
@@ -1,0 +1,45 @@
+name: Preview Build
+
+# Builds the site for PR previews. This workflow deliberately uses no
+# secrets, so it runs identically for same-repo branches and fork PRs
+# (GitHub withholds repository secrets from pull_request-triggered runs
+# of fork code). The built site is uploaded as an artifact, and the
+# separate "Preview Deploy" workflow (workflow_run-triggered, running in
+# this repository's context with secrets) picks it up and deploys it to
+# Cloudflare Pages.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update submodules
+        run: git submodule update --init --recursive
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Upload built site
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-dist
+          path: dist
+          retention-days: 3

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,60 +1,101 @@
 name: Preview Deploy
 
+# Deploys the preview built by the secretless "Preview Build" workflow and
+# comments the URL on the PR.
+#
+# This is split into two workflows so that fork PRs get previews.
+# pull_request-triggered runs of fork code never receive repository
+# secrets, so the Cloudflare deploy used to silently do nothing on
+# external PRs. The build now runs without secrets, and this
+# workflow_run-triggered workflow runs in the base repository's context
+# (from the workflow file on main) with access to secrets.
+#
+# Security: this workflow must never check out or execute code from the
+# PR. It only downloads the built static site artifact and pushes it to
+# Cloudflare Pages. The artifact content is untrusted, which is inherent
+# to preview deployments; the Cloudflare token is never exposed to the
+# PR's code.
+
 on:
-  pull_request:
-    branches: [main]
+  workflow_run:
+    workflows: ["Preview Build"]
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+
+concurrency: preview-deploy-${{ github.event.workflow_run.head_branch }}
 
 jobs:
-  preview:
+  deploy:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Update submodules
-        run: git submodule update --init --recursive
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Download built site
+        uses: actions/download-artifact@v4
         with:
-          node-version: '20'
-          cache: 'npm'
+          name: preview-dist
+          path: dist
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build project
-        run: npm run build
-
+      # shell: bash enables pipefail, so a failed wrangler deploy (or a
+      # missing alias URL) fails this step instead of passing silently.
+      # The branch name comes from a fork, so it is passed through the
+      # environment rather than interpolated into the script.
       - name: Deploy preview to Cloudflare Pages
         id: deploy
+        shell: bash
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          npx wrangler pages deploy dist --project-name neurosift --branch "${{ github.head_ref }}" 2>&1 | tee /tmp/deploy-output.txt
-          PREVIEW_URL=$(grep 'Deployment alias URL' /tmp/deploy-output.txt | grep -oP 'https://[^\s]+' || true)
+          npx wrangler pages deploy dist --project-name neurosift --branch "$HEAD_BRANCH" 2>&1 | tee /tmp/deploy-output.txt
+          PREVIEW_URL=$(grep 'Deployment alias URL' /tmp/deploy-output.txt | grep -oP 'https://[^\s]+')
           echo "preview_url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
 
+      # The workflow_run payload's pull_requests array is empty for fork
+      # PRs, so the PR is resolved from the head commit instead.
       - name: Comment preview URL on PR
-        if: steps.deploy.outputs.preview_url != ''
         uses: actions/github-script@v7
         with:
           script: |
             const previewUrl = '${{ steps.deploy.outputs.preview_url }}';
-            const body = `**Preview deployment ready!**\n\n${previewUrl}\n\n<sub>Built from ${context.sha.substring(0, 7)}</sub>`;
+            const headSha = context.payload.workflow_run.head_sha;
 
-            // Find existing bot comment to update
+            const { data: prs } =
+              await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: headSha,
+              });
+            const pr = prs.find(
+              (p) =>
+                p.state === "open" &&
+                p.base.repo.full_name ===
+                  `${context.repo.owner}/${context.repo.repo}`,
+            );
+            if (!pr) {
+              console.log("No open PR found for head sha, skipping comment.");
+              return;
+            }
+
+            const body = `**Preview deployment ready!**\n\n${previewUrl}\n\n<sub>Built from ${headSha.substring(0, 7)}</sub>`;
+
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
+              issue_number: pr.number,
             });
-
-            const botComment = comments.find(c =>
-              c.user.type === 'Bot' && c.body.includes('Preview deployment ready')
+            const botComment = comments.find(
+              (c) =>
+                c.user.type === "Bot" &&
+                c.body.includes("Preview deployment ready"),
             );
 
             if (botComment) {
@@ -68,7 +109,7 @@ jobs:
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                issue_number: context.issue.number,
+                issue_number: pr.number,
                 body,
               });
             }

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -10,6 +10,12 @@ name: Preview Deploy
 # workflow_run-triggered workflow runs in the base repository's context
 # (from the workflow file on main) with access to secrets.
 #
+# It can also be run manually via workflow_dispatch with the run id of a
+# "Preview Build" run, to re-deploy a preview or to test changes to this
+# workflow from a branch (workflow_run only triggers from the workflow
+# file on the default branch, but a manual dispatch runs the file from
+# the branch you dispatch it on).
+#
 # Security: this workflow must never check out or execute code from the
 # PR. It only downloads the built static site artifact and pushes it to
 # Cloudflare Pages. The artifact content is untrusted, which is inherent
@@ -20,27 +26,63 @@ on:
   workflow_run:
     workflows: ["Preview Build"]
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Run id of the Preview Build run whose artifact to deploy"
+        required: true
 
 permissions:
   actions: read
   pull-requests: write
 
-concurrency: preview-deploy-${{ github.event.workflow_run.head_branch }}
+concurrency: preview-deploy-${{ github.event.workflow_run.head_branch || inputs.run_id }}
 
 jobs:
   deploy:
     if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request'
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'pull_request')
     runs-on: ubuntu-latest
 
     steps:
+      # Resolve the build run to deploy: from the workflow_run payload, or
+      # from the run_id input on manual dispatch.
+      - name: Resolve build run
+        id: run
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let run;
+            if (context.eventName === "workflow_run") {
+              run = context.payload.workflow_run;
+            } else {
+              const runId = Number("${{ inputs.run_id }}");
+              const { data } = await github.rest.actions.getWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: runId,
+              });
+              run = data;
+              if (run.name !== "Preview Build" || run.conclusion !== "success") {
+                core.setFailed(
+                  `Run ${runId} is not a successful Preview Build run ` +
+                    `(name: ${run.name}, conclusion: ${run.conclusion})`,
+                );
+                return;
+              }
+            }
+            core.setOutput("run_id", run.id);
+            core.setOutput("head_branch", run.head_branch);
+            core.setOutput("head_sha", run.head_sha);
+
       - name: Download built site
         uses: actions/download-artifact@v4
         with:
           name: preview-dist
           path: dist
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ steps.run.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # shell: bash enables pipefail, so a failed wrangler deploy (or a
@@ -53,7 +95,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_BRANCH: ${{ steps.run.outputs.head_branch }}
         run: |
           npx wrangler pages deploy dist --project-name neurosift --branch "$HEAD_BRANCH" 2>&1 | tee /tmp/deploy-output.txt
           PREVIEW_URL=$(grep 'Deployment alias URL' /tmp/deploy-output.txt | grep -oP 'https://[^\s]+')
@@ -66,7 +108,7 @@ jobs:
         with:
           script: |
             const previewUrl = '${{ steps.deploy.outputs.preview_url }}';
-            const headSha = context.payload.workflow_run.head_sha;
+            const headSha = '${{ steps.run.outputs.head_sha }}';
 
             const { data: prs } =
               await github.rest.repos.listPullRequestsAssociatedWithCommit({


### PR DESCRIPTION
Preview deployments did not work for fork PRs (for example #436). GitHub withholds repository secrets from pull_request-triggered runs of fork code, so the Cloudflare deploy step ran with no credentials and wrangler failed with "Not logged in." The failure was also silent: the wrangler command was piped through tee without pipefail, so the preview check showed green while nothing deployed and no comment was posted.

This splits the preview into two workflows:

- **Preview Build** (`pull_request`): builds the site with no secrets, identically for same-repo and fork PRs, and uploads `dist/` as an artifact.
- **Preview Deploy** (`workflow_run`): runs in this repository's context with secrets after a successful build, downloads the artifact, deploys it to Cloudflare Pages, and comments the URL on the PR.

Security notes:

- The deploy workflow never checks out or executes PR code; it only handles the built static site, so the Cloudflare token is never exposed to the fork's code.
- The fork-controlled branch name is passed through the environment rather than interpolated into the script.
- The deploy step declares `shell: bash` so pipefail applies, and it fails if wrangler fails or no alias URL is produced, instead of passing silently.
- The PR to comment on is resolved from the head commit via the commits/pulls API, because the workflow_run payload's pull_requests array is empty for fork PRs.

One caveat for testing: workflow_run workflows only trigger from the workflow file on the default branch, so the deploy half takes effect after this merges. The build half runs on this PR itself. The manually-dispatched fork workflows from #435 are left in place and can be removed later if this makes them redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)