### PR TITLE
Add contributing guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## August 13, 2026
+
+- Added CONTRIBUTING.md with issue reporting and development guidelines
+
 ## August 5, 2026
 
 - PSTH group legend now labels boolean and bigint group values instead of showing "?"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,5 +47,6 @@ The repository also has pre-commit hooks (formatting and codespell) that you can
 ## Pull Requests
 
 - Update `CHANGELOG.md` with a brief entry describing your change.
-- Every pull request, including from forks, gets an automatic preview deployment. The build runs without secrets, and a separate workflow deploys the result and comments the preview URL on the PR. If your change affects a visualization, please include links demonstrating the before (production) and after (your preview) behavior on real data.
+- Every pull request, including from forks, gets an automatic preview deployment. The build runs without secrets, and a separate workflow deploys the result and comments the preview URL on the PR.
+- If your change fixes or modifies a visualization, the PR description should contain a link to the fixed widget on your preview deployment and a screenshot of it, ideally alongside a link showing the before behavior on production. Use real, publicly accessible data where possible, for the same reasons as in the issue guidelines above.
 - Keep changes minimal and focused. Small, reviewable diffs that fix one thing are much easier to merge than broad refactors.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing to Neurosift
+
+Thank you for your interest in contributing. Neurosift is a browser-based tool for visualizing neuroscience data, with a focus on NWB files and the DANDI Archive. This document describes how to report problems effectively and how to set up a development environment.
+
+## Reporting Problems with a Visualization
+
+If you are reporting an error with an existing visualization, please include both of the following in your issue:
+
+1. **A link to the visualization.** Use the share button in the tab toolbar, or copy the full URL from your browser. The URL should include the file (`url=...`), the dandiset (`dandisetId` and `dandisetVersion`), and the object being viewed (`tab=...`), so that anyone can open exactly what you were looking at. For example:
+
+   ```
+   https://neurosift.app/nwb?url=https://api.dandiarchive.org/api/assets/<asset-id>/download/&dandisetId=000000&dandisetVersion=0.230101.0000&tab=/acquisition/my_series
+   ```
+
+2. **A screenshot of the problem.** A picture of what you see, ideally with a note about what you expected instead.
+
+A few notes on choosing the example:
+
+- Prefer a published dandiset version over `draft` when possible. Draft assets can be replaced or removed, and dandisets can become embargoed, which makes the report impossible to reproduce later. We have had fixes become unverifiable because the only known example lived in a draft dandiset that was later embargoed.
+- If the data cannot be shared publicly, include a minimal script (for example using pynwb) that generates a small file reproducing the problem, and describe where in the file the affected object lives.
+
+## Development Setup
+
+```bash
+git clone https://github.com/flatironinstitute/neurosift
+cd neurosift
+git submodule update --init --recursive
+npm install
+npm run dev
+```
+
+The app will be served by Vite at http://localhost:5173. To view a local NWB file during development, you can serve it with a CORS- and range-request-capable server (for example `npx http-server -p 8321 --cors`) and open `http://localhost:5173/nwb?url=http://localhost:8321/myfile.nwb`.
+
+## Code Checks
+
+Before opening a pull request, please make sure the following pass:
+
+```bash
+npm run format:check   # prettier (npm run format to fix)
+npm run lint           # eslint
+npx tsc --noEmit       # type checking
+npm test               # unit tests (vitest)
+```
+
+The repository also has pre-commit hooks (formatting and codespell) that you can enable with `pre-commit install`.
+
+## Pull Requests
+
+- Update `CHANGELOG.md` with a brief entry describing your change.
+- Every pull request, including from forks, gets an automatic preview deployment. The build runs without secrets, and a separate workflow deploys the result and comments the preview URL on the PR. If your change affects a visualization, please include links demonstrating the before (production) and after (your preview) behavior on real data.
+- Keep changes minimal and focused. Small, reviewable diffs that fix one thing are much easier to merge than broad refactors.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ If you want to run neurosift on a local file, you can install it via pip and run
    ```
    
 
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for how to report problems (please include a link to the visualization and a screenshot) and how to set up a development environment.
+
 ## For developers
 
 Follow these steps to install and run the app locally in development mode:


### PR DESCRIPTION
Adds CONTRIBUTING.md and links it from the README.

The guide covers:

- How to report a problem with a visualization: include a link to the visualization itself (the full neurosift URL with `url`, `dandisetId`, `dandisetVersion`, and `tab`) and a screenshot of the problem. It also asks reporters to prefer published dandiset versions over drafts, since we have had fixes become unverifiable after the only known example moved into an embargoed draft dandiset (#335, #316).
- Development setup, including how to view a local NWB file against the dev server.
- Code checks to run before opening a PR. Note: the `npm test` line assumes #442 (which introduces the vitest harness) merges; if this lands first, that line can be dropped or that PR rebased.
- PR conventions: CHANGELOG entries, the automatic preview deployments (including for fork PRs, via #445), and a request to include before/after links when changing a visualization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)