### PR TITLE
Resolve LINDI soft links when reading groups and datasets

### DIFF
--- a/nextjs/neurosift-chat-agent-tools/src/lib/tools/remote-h5-file/lib/lindi/RemoteH5FileLindi.ts
+++ b/nextjs/neurosift-chat-agent-tools/src/lib/tools/remote-h5-file/lib/lindi/RemoteH5FileLindi.ts
@@ -164,6 +164,10 @@ export class ZarrFileSystemClient {
   }
 }
 
+// A soft link may point at another soft link, but a chain this long means the
+// file is malformed, most likely a cycle.
+const maxSoftLinkHops = 10;
+
 class RemoteH5FileLindi {
   #cacheDisabled = false; // just for benchmarking
   #sourceUrls: string[] | undefined = undefined;
@@ -215,12 +219,35 @@ class RemoteH5FileLindi {
   get dataIsRemote() {
     return !this.url.startsWith("http://localhost");
   }
+  // LINDI represents an HDF5 soft link as a zarr group whose .zattrs contains a
+  // _SOFT_LINK entry naming the target path. Such a link stands in for whatever
+  // it points at, so every read needs to follow it to the target before looking
+  // for .zgroup, .zarray or chunk data. This is common in NWB files: pynwb
+  // writes a soft link whenever the same timestamps dataset or rois
+  // DynamicTableRegion is shared by more than one TimeSeries.
+  async resolveSoftLink(pathWithoutBeginningSlash: string): Promise<string> {
+    let p = pathWithoutBeginningSlash;
+    // guard against a link cycle in a malformed file
+    for (let i = 0; i < maxSoftLinkHops; i++) {
+      if (p === "") return p; // the root group is never a link
+      const zattrs = (await this.lindiFileSystemClient.readJson(
+        p + "/.zattrs",
+      )) as ZMetaDataZAttrs | undefined;
+      const target = zattrs?.["_SOFT_LINK"]?.["path"];
+      if (typeof target !== "string") return p;
+      p = target.startsWith("/") ? target.slice(1) : target;
+    }
+    console.warn(
+      `Too many soft link hops while resolving ${pathWithoutBeginningSlash}`,
+    );
+    return p;
+  }
   async getGroup(path: string): Promise<RemoteH5Group | undefined> {
     if (path === "") path = "/";
     let group: RemoteH5Group | undefined;
-    const pathWithoutBeginningSlash = path.startsWith("/")
-      ? path.slice(1)
-      : path;
+    const pathWithoutBeginningSlash = await this.resolveSoftLink(
+      path.startsWith("/") ? path.slice(1) : path,
+    );
     let zgroup: ZMetaDataZGroup | undefined;
     let zattrs: ZMetaDataZAttrs | undefined;
     if (path === "/") {
@@ -244,22 +271,35 @@ class RemoteH5FileLindi {
       const childPaths: string[] =
         this.pathsByParentPath[pathWithoutBeginningSlash] || [];
       for (const childPath of childPaths) {
+        // A soft-linked child is reported as the kind of object it points at,
+        // with the attributes of that object, but under its own name and path.
+        // If the link is broken we fall back to the link itself, which LINDI
+        // stores as an empty group.
+        let resolvedChildPath = await this.resolveSoftLink(childPath);
+        if (
+          resolvedChildPath !== childPath &&
+          !(await this.lindiFileSystemClient.readJson(
+            resolvedChildPath + "/.zgroup",
+          )) &&
+          !(await this.lindiFileSystemClient.readJson(
+            resolvedChildPath + "/.zarray",
+          ))
+        ) {
+          console.warn(
+            `Soft link ${childPath} points at ${resolvedChildPath}, which was not found`,
+          );
+          resolvedChildPath = childPath;
+        }
         const childZgroup = await this.lindiFileSystemClient.readJson(
-          childPath + "/.zgroup",
+          resolvedChildPath + "/.zgroup",
         );
         const childZarray = await this.lindiFileSystemClient.readJson(
-          childPath + "/.zarray",
+          resolvedChildPath + "/.zarray",
         );
         const childZattrs = await this.lindiFileSystemClient.readJson(
-          childPath + "/.zattrs",
+          resolvedChildPath + "/.zattrs",
         );
-        if (childZgroup) {
-          subgroups.push({
-            name: getNameFromPath(childPath),
-            path: "/" + childPath,
-            attrs: childZattrs || {},
-          });
-        } else if (childZarray) {
+        if (childZarray) {
           const shape = childZarray.shape;
           const dtype = childZarray.dtype;
           if (shape && dtype) {
@@ -271,8 +311,18 @@ class RemoteH5FileLindi {
               attrs: childZattrs || {},
             });
           } else {
-            console.warn("Unexpected .zarray item", childPath, childZarray);
+            console.warn(
+              "Unexpected .zarray item",
+              resolvedChildPath,
+              childZarray,
+            );
           }
+        } else if (childZgroup) {
+          subgroups.push({
+            name: getNameFromPath(childPath),
+            path: "/" + childPath,
+            attrs: childZattrs || {},
+          });
         }
       }
       group = {
@@ -286,9 +336,9 @@ class RemoteH5FileLindi {
     return group;
   }
   async getDataset(path: string): Promise<RemoteH5Dataset | undefined> {
-    const pathWithoutBeginningSlash = path.startsWith("/")
-      ? path.slice(1)
-      : path;
+    const pathWithoutBeginningSlash = await this.resolveSoftLink(
+      path.startsWith("/") ? path.slice(1) : path,
+    );
     const zarray = (await this.lindiFileSystemClient.readJson(
       pathWithoutBeginningSlash + "/.zarray",
     )) as ZMetaDataZArray;
@@ -338,9 +388,9 @@ class RemoteH5FileLindi {
       );
     }
 
-    const pathWithoutBeginningSlash = path.startsWith("/")
-      ? path.slice(1)
-      : path;
+    const pathWithoutBeginningSlash = await this.resolveSoftLink(
+      path.startsWith("/") ? path.slice(1) : path,
+    );
     const zarray = (await this.lindiFileSystemClient.readJson(
       pathWithoutBeginningSlash + "/.zarray",
     )) as ZMetaDataZArray | undefined;

--- a/src/pages/NwbPage/hdf5Cache.ts
+++ b/src/pages/NwbPage/hdf5Cache.ts
@@ -6,7 +6,10 @@ interface CachedItem {
 }
 
 const DB_NAME = "neurosift-hdf5-cache";
-const DB_VERSION = 1;
+// Bump this whenever a change to the readers means that a previously cached
+// group or dataset listing is no longer what we would produce today. Version 2
+// discards listings made before soft links were resolved in LINDI files.
+const DB_VERSION = 2;
 const STORE_NAME = "hdf5-objects";
 const MAX_CACHED_ITEMS = 1000; // Clear cache when this many items are stored
 
@@ -30,6 +33,11 @@ const initializeDb = async () => {
     request.onupgradeneeded = (event: Event) => {
       const target = event.target as IDBOpenDBRequest;
       const database = target.result;
+      // Cached items are only ever a copy of what the readers produce, so on a
+      // version change we drop the store and start over rather than migrate.
+      if (database.objectStoreNames.contains(STORE_NAME)) {
+        database.deleteObjectStore(STORE_NAME);
+      }
       database.createObjectStore(STORE_NAME, { keyPath: "key" });
     };
   });

--- a/src/remote-h5-file/lib/lindi/RemoteH5FileLindi.test.ts
+++ b/src/remote-h5-file/lib/lindi/RemoteH5FileLindi.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from "vitest";
+import type RemoteH5FileLindiType from "./RemoteH5FileLindi";
+import type { ZarrFileSystemClient as ZarrFileSystemClientType } from "./RemoteH5FileLindi";
+
+// The LINDI reader imports the worker-backed HDF5 reader, which creates a web
+// worker when its module is loaded, so a stub is needed to import it in node.
+vi.stubGlobal(
+  "Worker",
+  class {
+    postMessage() {}
+    addEventListener() {}
+    removeEventListener() {}
+    terminate() {}
+  },
+);
+if (typeof URL.createObjectURL !== "function") {
+  URL.createObjectURL = () => "blob:stub";
+}
+const { default: RemoteH5FileLindi, ZarrFileSystemClient } =
+  await import("./RemoteH5FileLindi");
+
+// A small stand-in for an NWB file in which one RoiResponseSeries owns its
+// timestamps and a second one soft links to them, which is what pynwb writes
+// when the same timestamps object is passed to more than one series.
+const metadata: { [key: string]: unknown } = {
+  ".zgroup": { zarr_format: 2 },
+  ".zattrs": {},
+
+  "Corrected/.zgroup": { zarr_format: 2 },
+  "Corrected/.zattrs": { neurodata_type: "RoiResponseSeries" },
+  "Corrected/data/.zarray": {
+    zarr_format: 2,
+    shape: [10, 3],
+    dtype: "<f4",
+    chunks: [10, 3],
+  },
+  "Corrected/data/.zattrs": { unit: "n.a." },
+  "Corrected/timestamps/.zarray": {
+    zarr_format: 2,
+    shape: [10],
+    dtype: "<f8",
+    chunks: [10],
+  },
+  "Corrected/timestamps/.zattrs": { unit: "seconds", interval: 1 },
+
+  "DfOverF/.zgroup": { zarr_format: 2 },
+  "DfOverF/.zattrs": { neurodata_type: "RoiResponseSeries" },
+  "DfOverF/data/.zarray": {
+    zarr_format: 2,
+    shape: [10, 3],
+    dtype: "<f4",
+    chunks: [10, 3],
+  },
+  "DfOverF/data/.zattrs": { unit: "a.u." },
+  "DfOverF/timestamps/.zgroup": { zarr_format: 2 },
+  "DfOverF/timestamps/.zattrs": {
+    _SOFT_LINK: { path: "/Corrected/timestamps" },
+  },
+
+  "LinkedSeries/.zgroup": { zarr_format: 2 },
+  "LinkedSeries/.zattrs": { _SOFT_LINK: { path: "/Corrected" } },
+
+  "BrokenLink/.zgroup": { zarr_format: 2 },
+  "BrokenLink/.zattrs": { _SOFT_LINK: { path: "/does/not/exist" } },
+
+  "CycleA/.zgroup": { zarr_format: 2 },
+  "CycleA/.zattrs": { _SOFT_LINK: { path: "/CycleB" } },
+  "CycleB/.zgroup": { zarr_format: 2 },
+  "CycleB/.zattrs": { _SOFT_LINK: { path: "/CycleA" } },
+};
+
+const pathsByParentPath: { [key: string]: string[] } = {
+  "": [
+    "Corrected",
+    "DfOverF",
+    "LinkedSeries",
+    "BrokenLink",
+    "CycleA",
+    "CycleB",
+  ],
+  Corrected: ["Corrected/data", "Corrected/timestamps"],
+  DfOverF: ["DfOverF/data", "DfOverF/timestamps"],
+};
+
+const createFile = () => {
+  const client = new ZarrFileSystemClient("http://localhost/test", {
+    metadata,
+  });
+  // The constructor is not part of the public API; files are normally created
+  // through RemoteH5FileLindi.create, which fetches the sidecar.
+  const Ctor = RemoteH5FileLindi as unknown as new (
+    url: string,
+    client: ZarrFileSystemClientType,
+    pathsByParentPath: { [key: string]: string[] },
+  ) => RemoteH5FileLindiType;
+  return new Ctor("http://localhost/test", client, pathsByParentPath);
+};
+
+describe("RemoteH5FileLindi soft links", () => {
+  it("reports a soft-linked dataset as a dataset of the group", async () => {
+    const f = createFile();
+    const group = await f.getGroup("/DfOverF");
+    expect(group).toBeDefined();
+    const names = group!.datasets.map((ds) => ds.name).sort();
+    expect(names).toEqual(["data", "timestamps"]);
+    expect(group!.subgroups).toEqual([]);
+  });
+
+  it("gives the soft-linked dataset the shape and attributes of its target", async () => {
+    const f = createFile();
+    const group = await f.getGroup("/DfOverF");
+    const ts = group!.datasets.find((ds) => ds.name === "timestamps");
+    expect(ts).toBeDefined();
+    expect(ts!.shape).toEqual([10]);
+    expect(ts!.dtype).toBe("<f8");
+    expect(ts!.attrs).toEqual({ unit: "seconds", interval: 1 });
+    // the link keeps its own path, not that of the target
+    expect(ts!.path).toBe("/DfOverF/timestamps");
+  });
+
+  it("resolves a soft link when the dataset itself is requested", async () => {
+    const f = createFile();
+    const ds = await f.getDataset("/DfOverF/timestamps");
+    expect(ds).toBeDefined();
+    expect(ds!.shape).toEqual([10]);
+    expect(ds!.dtype).toBe("<f8");
+    expect(ds!.attrs).toEqual({ unit: "seconds", interval: 1 });
+  });
+
+  it("leaves a plain dataset alone", async () => {
+    const f = createFile();
+    const ds = await f.getDataset("/Corrected/timestamps");
+    expect(ds!.shape).toEqual([10]);
+    expect(ds!.attrs).toEqual({ unit: "seconds", interval: 1 });
+  });
+
+  it("resolves a soft link to a group", async () => {
+    const f = createFile();
+    const root = await f.getGroup("/");
+    const linked = root!.subgroups.find((sg) => sg.name === "LinkedSeries");
+    expect(linked).toBeDefined();
+    expect(linked!.attrs).toEqual({ neurodata_type: "RoiResponseSeries" });
+
+    const group = await f.getGroup("/LinkedSeries");
+    expect(group!.datasets.map((ds) => ds.name).sort()).toEqual([
+      "data",
+      "timestamps",
+    ]);
+  });
+
+  it("falls back to the link itself when the target is missing", async () => {
+    const f = createFile();
+    const root = await f.getGroup("/");
+    const broken = root!.subgroups.find((sg) => sg.name === "BrokenLink");
+    expect(broken).toBeDefined();
+    expect(broken!.path).toBe("/BrokenLink");
+  });
+
+  it("does not follow a cycle of soft links indefinitely", async () => {
+    const f = createFile();
+    const root = await f.getGroup("/");
+    expect(root!.subgroups.map((sg) => sg.name)).toContain("CycleA");
+  });
+});

--- a/src/remote-h5-file/lib/lindi/RemoteH5FileLindi.ts
+++ b/src/remote-h5-file/lib/lindi/RemoteH5FileLindi.ts
@@ -170,6 +170,10 @@ export class ZarrFileSystemClient {
   }
 }
 
+// A soft link may point at another soft link, but a chain this long means the
+// file is malformed, most likely a cycle.
+const maxSoftLinkHops = 10;
+
 class RemoteH5FileLindi {
   #cacheDisabled = false; // just for benchmarking
   #sourceUrls: string[] | undefined = undefined;
@@ -223,12 +227,35 @@ class RemoteH5FileLindi {
   get dataIsRemote() {
     return !this.url.startsWith("http://localhost");
   }
+  // LINDI represents an HDF5 soft link as a zarr group whose .zattrs contains a
+  // _SOFT_LINK entry naming the target path. Such a link stands in for whatever
+  // it points at, so every read needs to follow it to the target before looking
+  // for .zgroup, .zarray or chunk data. This is common in NWB files: pynwb
+  // writes a soft link whenever the same timestamps dataset or rois
+  // DynamicTableRegion is shared by more than one TimeSeries.
+  async resolveSoftLink(pathWithoutBeginningSlash: string): Promise<string> {
+    let p = pathWithoutBeginningSlash;
+    // guard against a link cycle in a malformed file
+    for (let i = 0; i < maxSoftLinkHops; i++) {
+      if (p === "") return p; // the root group is never a link
+      const zattrs = (await this.lindiFileSystemClient.readJson(
+        p + "/.zattrs",
+      )) as ZMetaDataZAttrs | undefined;
+      const target = zattrs?.["_SOFT_LINK"]?.["path"];
+      if (typeof target !== "string") return p;
+      p = target.startsWith("/") ? target.slice(1) : target;
+    }
+    console.warn(
+      `Too many soft link hops while resolving ${pathWithoutBeginningSlash}`,
+    );
+    return p;
+  }
   async getGroup(path: string): Promise<RemoteH5Group | undefined> {
     if (path === "") path = "/";
     let group: RemoteH5Group | undefined;
-    const pathWithoutBeginningSlash = path.startsWith("/")
-      ? path.slice(1)
-      : path;
+    const pathWithoutBeginningSlash = await this.resolveSoftLink(
+      path.startsWith("/") ? path.slice(1) : path,
+    );
     let zgroup: ZMetaDataZGroup | undefined;
     let zattrs: ZMetaDataZAttrs | undefined;
     if (path === "/") {
@@ -252,22 +279,35 @@ class RemoteH5FileLindi {
       const childPaths: string[] =
         this.pathsByParentPath[pathWithoutBeginningSlash] || [];
       for (const childPath of childPaths) {
+        // A soft-linked child is reported as the kind of object it points at,
+        // with the attributes of that object, but under its own name and path.
+        // If the link is broken we fall back to the link itself, which LINDI
+        // stores as an empty group.
+        let resolvedChildPath = await this.resolveSoftLink(childPath);
+        if (
+          resolvedChildPath !== childPath &&
+          !(await this.lindiFileSystemClient.readJson(
+            resolvedChildPath + "/.zgroup",
+          )) &&
+          !(await this.lindiFileSystemClient.readJson(
+            resolvedChildPath + "/.zarray",
+          ))
+        ) {
+          console.warn(
+            `Soft link ${childPath} points at ${resolvedChildPath}, which was not found`,
+          );
+          resolvedChildPath = childPath;
+        }
         const childZgroup = await this.lindiFileSystemClient.readJson(
-          childPath + "/.zgroup",
+          resolvedChildPath + "/.zgroup",
         );
         const childZarray = await this.lindiFileSystemClient.readJson(
-          childPath + "/.zarray",
+          resolvedChildPath + "/.zarray",
         );
         const childZattrs = await this.lindiFileSystemClient.readJson(
-          childPath + "/.zattrs",
+          resolvedChildPath + "/.zattrs",
         );
-        if (childZgroup) {
-          subgroups.push({
-            name: getNameFromPath(childPath),
-            path: "/" + childPath,
-            attrs: childZattrs || {},
-          });
-        } else if (childZarray) {
+        if (childZarray) {
           const shape = childZarray.shape;
           const dtype = childZarray.dtype;
           if (shape && dtype) {
@@ -282,8 +322,18 @@ class RemoteH5FileLindi {
               filters: formatFilters(childZarray.filters),
             });
           } else {
-            console.warn("Unexpected .zarray item", childPath, childZarray);
+            console.warn(
+              "Unexpected .zarray item",
+              resolvedChildPath,
+              childZarray,
+            );
           }
+        } else if (childZgroup) {
+          subgroups.push({
+            name: getNameFromPath(childPath),
+            path: "/" + childPath,
+            attrs: childZattrs || {},
+          });
         }
       }
       group = {
@@ -297,9 +347,9 @@ class RemoteH5FileLindi {
     return group;
   }
   async getDataset(path: string): Promise<RemoteH5Dataset | undefined> {
-    const pathWithoutBeginningSlash = path.startsWith("/")
-      ? path.slice(1)
-      : path;
+    const pathWithoutBeginningSlash = await this.resolveSoftLink(
+      path.startsWith("/") ? path.slice(1) : path,
+    );
     const zarray = (await this.lindiFileSystemClient.readJson(
       pathWithoutBeginningSlash + "/.zarray",
     )) as ZMetaDataZArray;
@@ -352,9 +402,9 @@ class RemoteH5FileLindi {
       );
     }
 
-    const pathWithoutBeginningSlash = path.startsWith("/")
-      ? path.slice(1)
-      : path;
+    const pathWithoutBeginningSlash = await this.resolveSoftLink(
+      path.startsWith("/") ? path.slice(1) : path,
+    );
     const zarray = (await this.lindiFileSystemClient.readJson(
       pathWithoutBeginningSlash + "/.zarray",
     )) as ZMetaDataZArray | undefined;


### PR DESCRIPTION
Fixes #448.

LINDI serializes an HDF5 soft link as a zarr group whose `.zattrs` holds a `_SOFT_LINK` entry naming the target path. We were not reading that entry anywhere, so a soft-linked child was reported as a subgroup no matter what it pointed at, and there was no `.zarray` at its path to read from.

The visible effect was that a `RoiResponseSeries` whose timestamps are shared with another series got no timeseries widget, because `simpleTimeseriesPlugin.canHandle` looks for a dataset named `timestamps` among the group's datasets. In dandiset 000728, `/processing/ophys/DfOverF/DfOverF` soft links its `timestamps` and `rois` to `/processing/ophys/Fluorescence/Corrected`, and only `Corrected` got a widget. Since pynwb writes a soft link whenever the same `timestamps` object or `rois` `DynamicTableRegion` is passed to more than one series, this pattern is common.

## What changed

`RemoteH5FileLindi` now follows a soft link to its target in `getGroup`, `getDataset` and `getDatasetData`. A linked child keeps its own name and path but takes the kind, shape, dtype and attributes of the object it points at, which is what the h5wasm reader already does for the same file. A link whose target is missing falls back to the link itself, and a chain of links is followed to a fixed depth so that a cycle in a malformed file cannot hang the reader.

The group and dataset listings are cached in IndexedDB by asset URL and path, with no record of which reader produced them and no invalidation. Without a version bump, anyone who has already viewed a file would keep the stale listing and see no change, so `hdf5Cache` is now at version 2 and drops the old store on upgrade.

The same change is applied to the copy of the reader vendored under `nextjs/neurosift-chat-agent-tools`, which has the same gap.

## Testing

New unit tests in `RemoteH5FileLindi.test.ts` cover a soft-linked dataset, a soft-linked group, a broken link and a link cycle, against an in-memory zarr metadata fixture. Four of the seven fail without the fix.

Checked against the real asset from the issue, reading through the actual LINDI sidecar: `timestamps` and `rois` now come back as datasets of shape `[113855]` and `[171]` with the target's attributes, and `getDatasetData` on the link path returns the timestamps themselves.

Running the dev server against the same file, `/processing/ophys/DfOverF/DfOverF` now shows the timeseries widget. `/processing/ophys/Fluorescence/Corrected`, which already worked, is unchanged, and `/processing/ophys/ImageSegmentation/PlaneSegmentation` still renders its table and ROI masks.

Draft because I have only exercised this on dandiset 000728. Other files in the archive use soft links for `device`, `imaging_plane` and `indexed_timeseries`, which now report the target's attributes rather than an empty group, and it would be worth a second look at a few of those before merging.
