### PR TITLE
Fix misaligned LINDI reads across trailing-dimension chunks

### DIFF
--- a/src/remote-h5-file/lib/lindi/lindiDatasetDataLoader.test.ts
+++ b/src/remote-h5-file/lib/lindi/lindiDatasetDataLoader.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The loader's module graph reaches the worker-backed HDF5 reader, which
+// creates a web worker at import time, so stub it out for node.
+vi.stubGlobal(
+  "Worker",
+  class {
+    postMessage() {}
+    addEventListener() {}
+    removeEventListener() {}
+    terminate() {}
+  },
+);
+if (typeof URL.createObjectURL !== "function") {
+  URL.createObjectURL = () => "blob:stub";
+}
+const { default: lindiDatasetDataLoader } =
+  await import("./lindiDatasetDataLoader");
+
+const prod = (a: number[]) => a.reduce((x, y) => x * y, 1);
+
+const rowMajorStrides = (shape: number[]) => {
+  const strides = new Array(shape.length).fill(1);
+  for (let d = shape.length - 2; d >= 0; d--) {
+    strides[d] = strides[d + 1] * shape[d + 1];
+  }
+  return strides;
+};
+
+const unravel = (i: number, shape: number[]) => {
+  const index = new Array(shape.length).fill(0);
+  let rem = i;
+  for (let d = shape.length - 1; d >= 0; d--) {
+    index[d] = rem % shape[d];
+    rem = Math.floor(rem / shape[d]);
+  }
+  return index;
+};
+
+// Build an in-memory chunk store for an array whose value at each position is
+// its flat row-major index. Chunks are stored at full chunk size with zero
+// padding beyond the array edge, as HDF5 and zarr store them, so a loader that
+// uses chunk strides where it should use array strides reads padding.
+const makeChunkStore = (
+  shape: number[],
+  chunkShape: number[],
+  dtype: "<f4" | "<i4",
+) => {
+  const macro = chunkShape.map((cs, d) => Math.ceil(shape[d] / cs));
+  const shapeStrides = rowMajorStrides(shape);
+  const chunks: { [path: string]: Float32Array | Int32Array } = {};
+  const numChunks = prod(macro);
+  for (let ci = 0; ci < numChunks; ci++) {
+    const c = unravel(ci, macro);
+    const arr =
+      dtype === "<f4"
+        ? new Float32Array(prod(chunkShape))
+        : new Int32Array(prod(chunkShape));
+    for (let k = 0; k < arr.length; k++) {
+      const local = unravel(k, chunkShape);
+      let inside = true;
+      let flat = 0;
+      for (let d = 0; d < shape.length; d++) {
+        const g = c[d] * chunkShape[d] + local[d];
+        if (g >= shape[d]) {
+          inside = false;
+          break;
+        }
+        flat += g * shapeStrides[d];
+      }
+      arr[k] = inside ? flat : 0;
+    }
+    chunks["x/" + c.join(".")] = arr;
+  }
+  const readPaths: string[] = [];
+  const client = {
+    readBinary: async (path: string, o: { decodeArray?: boolean }) => {
+      if (!o.decodeArray) throw Error("Unexpected raw read of " + path);
+      readPaths.push(path);
+      return chunks[path];
+    },
+  };
+  const zarray = {
+    zarr_format: 2 as const,
+    shape,
+    chunks: chunkShape,
+    dtype,
+    // A compressor keeps the loader off the single contiguous block path,
+    // which reads byte ranges rather than decoded chunks.
+    compressor: { id: "zlib", level: 4 },
+    filters: [],
+    fill_value: 0,
+    order: "C" as const,
+  };
+  return { client, zarray, readPaths };
+};
+
+// Expected values for a slice of the first up-to-three dimensions, computed
+// straight from the flat index formula.
+const expectedSlice = (shape: number[], slice: [number, number][]) => {
+  const strides = rowMajorStrides(shape);
+  const full: [number, number][] = shape.map((n, d) =>
+    d < slice.length ? slice[d] : [0, n],
+  );
+  const out: number[] = [];
+  const rec = (d: number, base: number) => {
+    if (d === shape.length) {
+      out.push(base);
+      return;
+    }
+    for (let i = full[d][0]; i < full[d][1]; i++) {
+      rec(d + 1, base + i * strides[d]);
+    }
+  };
+  rec(0, 0);
+  return out;
+};
+
+const load = async (
+  shape: number[],
+  chunkShape: number[],
+  slice: [number, number][],
+  dtype: "<f4" | "<i4" = "<f4",
+) => {
+  const { client, zarray, readPaths } = makeChunkStore(
+    shape,
+    chunkShape,
+    dtype,
+  );
+  const result = await lindiDatasetDataLoader({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    client: client as any,
+    path: "x",
+    zarray,
+    slice,
+  });
+  return { result: Array.from(result as ArrayLike<number>), readPaths };
+};
+
+describe("lindiDatasetDataLoader", () => {
+  it("reads a 1-D array across chunks", async () => {
+    const { result } = await load([10], [4], [[1, 9]]);
+    expect(result).toEqual(expectedSlice([10], [[1, 9]]));
+  });
+
+  it("reads a 2-D slice across chunks in both dimensions", async () => {
+    const shape = [5, 6];
+    const chunks = [2, 4];
+    const slice: [number, number][] = [
+      [1, 5],
+      [1, 6],
+    ];
+    const { result } = await load(shape, chunks, slice);
+    expect(result).toEqual(expectedSlice(shape, slice));
+  });
+
+  it("uses a contiguous slice when the chunk layout matches the array", async () => {
+    const shape = [2, 3, 8];
+    const chunks = [1, 3, 8];
+    const slice: [number, number][] = [
+      [1, 2],
+      [0, 3],
+    ];
+    const { result, readPaths } = await load(shape, chunks, slice);
+    expect(result).toEqual(expectedSlice(shape, slice));
+    expect(readPaths).toEqual(["x/1.0.0"]);
+  });
+
+  it("handles a padded single chunk in the third dimension", async () => {
+    // Chunk is wider than the array in the last dimension, so chunk rows are
+    // longer than array rows and a contiguous slice would include padding.
+    const shape = [4, 5, 7];
+    const chunks = [2, 5, 8];
+    const slice: [number, number][] = [
+      [1, 3],
+      [0, 5],
+    ];
+    const { result } = await load(shape, chunks, slice);
+    expect(result.length).toBe(2 * 5 * 7);
+    expect(result).toEqual(expectedSlice(shape, slice));
+  });
+
+  it("concatenates several chunks along the third dimension that divide the shape evenly", async () => {
+    const shape = [2, 3, 8];
+    const chunks = [1, 3, 4];
+    const slice: [number, number][] = [
+      [0, 2],
+      [0, 3],
+    ];
+    const { result } = await load(shape, chunks, slice);
+    expect(result).toEqual(expectedSlice(shape, slice));
+  });
+
+  it("concatenates several chunks along the third dimension when the last chunk is partial", async () => {
+    // Like an image stack of shape [T, H, W] chunked [1, H, 4] with W = 10.
+    const shape = [3, 4, 10];
+    const chunks = [1, 4, 4];
+    const slice: [number, number][] = [
+      [1, 2],
+      [0, 4],
+    ];
+    const { result } = await load(shape, chunks, slice);
+    expect(result.length).toBe(1 * 4 * 10);
+    expect(result).toEqual(expectedSlice(shape, slice));
+  });
+
+  it("slices the second dimension while concatenating trailing chunks", async () => {
+    const shape = [3, 4, 10];
+    const chunks = [1, 4, 4];
+    const slice: [number, number][] = [
+      [0, 3],
+      [1, 3],
+    ];
+    const { result } = await load(shape, chunks, slice);
+    expect(result).toEqual(expectedSlice(shape, slice));
+  });
+
+  it("handles chunks along two trailing dimensions with padding in both", async () => {
+    const shape = [2, 3, 5, 6];
+    const chunks = [1, 3, 2, 4];
+    const slice: [number, number][] = [
+      [0, 2],
+      [0, 3],
+    ];
+    const { result } = await load(shape, chunks, slice);
+    expect(result.length).toBe(2 * 3 * 5 * 6);
+    expect(result).toEqual(expectedSlice(shape, slice));
+  });
+
+  it("handles a 4-D array chunked in every dimension", async () => {
+    const shape = [3, 5, 5, 6];
+    const chunks = [2, 2, 2, 4];
+    const slice: [number, number][] = [
+      [1, 3],
+      [1, 4],
+    ];
+    const { result } = await load(shape, chunks, slice, "<i4");
+    expect(result).toEqual(expectedSlice(shape, slice));
+  });
+
+  it("supports a third slice dimension on top of trailing chunks", async () => {
+    const shape = [3, 4, 10];
+    const chunks = [1, 4, 4];
+    const slice: [number, number][] = [
+      [0, 3],
+      [0, 4],
+      [2, 7],
+    ];
+    const { result } = await load(shape, chunks, slice);
+    expect(result).toEqual(expectedSlice(shape, slice));
+  });
+
+  it("supports a third slice dimension on a 4-D array", async () => {
+    const shape = [2, 3, 5, 6];
+    const chunks = [1, 3, 2, 4];
+    const slice: [number, number][] = [
+      [0, 2],
+      [1, 3],
+      [1, 4],
+    ];
+    const { result } = await load(shape, chunks, slice);
+    expect(result).toEqual(expectedSlice(shape, slice));
+  });
+});

--- a/src/remote-h5-file/lib/lindi/lindiDatasetDataLoader.ts
+++ b/src/remote-h5-file/lib/lindi/lindiDatasetDataLoader.ts
@@ -176,18 +176,27 @@ const lindiDatasetDataLoader = async (o: {
   const i2StartChunk = ndims > 1 ? Math.floor(i2Start / chunkShape[1]) : 0;
   const i2EndChunk = ndims > 1 ? Math.floor((i2End - 1) / chunkShape[1]) : 0;
   if (i1StartChunk === i1EndChunk && i2StartChunk === i2EndChunk) {
-    // With respect to the first two dimensions,
-    // we are entirely within a single chunk.
+    // With respect to the first two dimensions, we are entirely within a
+    // single chunk. There may still be several chunks along the remaining
+    // dimensions, and the last chunk along each of those dimensions may be
+    // padded beyond the array shape, so each chunk is copied into its own
+    // region of the output using the array's strides rather than the chunk's.
+    const n1 = i1End - i1Start;
+    const n2 = i2End - i2Start;
+    const j1Start = i1Start - i1StartChunk * chunkShape[0];
+    const j2Start = i2Start - i2StartChunk * chunkShape2;
+    const trailingShape = shape.slice(2);
+    const trailingChunkShape = chunkShape.slice(2);
+    const trailingMacroChunkShape = macroChunkShape.slice(2);
+    const numTrailingDims = trailingShape.length;
+    const outStrides = rowMajorStrides(trailingShape);
+    const chunkStrides = rowMajorStrides(trailingChunkShape);
 
-    if (prodMacroChunkShapeAllButFirstTwoDimensions === 1) {
-      // in this case we are truly in a single chunk because there is only one chunk in the other dimensions
-      let chunkPath = path + "/" + i1StartChunk;
-      if (ndims > 1) {
-        chunkPath += "." + i2StartChunk;
-      }
-      for (let d = 2; d < ndims; d++) {
-        chunkPath += ".0";
-      }
+    const chunkPathPrefix =
+      path + "/" + i1StartChunk + (ndims > 1 ? "." + i2StartChunk : "");
+    const readChunk = async (trailingChunkIndex: number[]) => {
+      const chunkPath =
+        chunkPathPrefix + trailingChunkIndex.map((c) => "." + c).join("");
       const x = await client.readBinary(chunkPath, {
         decodeArray: true,
         disableCache: o.disableCache,
@@ -207,157 +216,84 @@ const lindiDatasetDataLoader = async (o: {
         });
         throw Error("Unable to read chunk: " + chunkPath);
       }
-      const j1Start = i1Start - i1StartChunk * chunkShape[0];
-      const j1End = i1End - i1StartChunk * chunkShape[0];
-      const j2Start = i2Start - i2StartChunk * chunkShape2;
-      const j2End = i2End - i2StartChunk * chunkShape2;
-      const slicingInSecondDimension =
-        ndims > 1 && (j2Start > 0 || j2End < chunkShape2);
-      if (!slicingInSecondDimension) {
-        // we are not slicing in second dimension. In this case we don't need to make a copy of the data
-        const ret = x.slice(
-          j1Start * prodChunkSizeOfAllButFirstDimension,
-          j1End * prodChunkSizeOfAllButFirstDimension,
-        );
-        return ret;
-      } else {
-        // we are slicing in second dimension, so we need to make a copy of the data
-        const ret = allocateArrayWithDtype(
-          (i1End - i1Start) *
-            (i2End - i2Start) *
-            prodShapeSizeOfAllButFirstTwoDimensions,
-          dtype,
-        );
-        let iRet = 0;
-        for (let j1 = j1Start; j1 < j1End; j1++) {
-          for (let j2 = j2Start; j2 < j2End; j2++) {
-            for (
-              let j3 = 0;
-              j3 < prodShapeSizeOfAllButFirstTwoDimensions;
-              j3++
-            ) {
-              ret[iRet] =
-                x[
-                  (j1 * chunkShape2 + j2) *
-                    prodChunkSizeOfAllButFirstTwoDimensions +
-                    j3
-                ];
-              iRet++;
-            }
-          }
-        }
-        return ret;
-      }
-    } else {
-      // there is more than one chunk in the other dimensions, and we need to concatenate them
-      if (ndims > 4) {
-        throw Error("Case not yet supported: C2");
-      }
-      while (macroChunkShape.length < 4) {
-        macroChunkShape.push(1);
-      }
-      const retList = [];
-      for (let iii3 = 0; iii3 < macroChunkShape[2]; iii3++) {
-        for (let iii4 = 0; iii4 < macroChunkShape[3]; iii4++) {
-          let chunkPath = path + "/" + i1StartChunk;
-          chunkPath += "." + i2StartChunk;
-          chunkPath += "." + iii3;
-          if (ndims === 4) {
-            chunkPath += "." + iii4;
-          }
-          const x = await client.readBinary(chunkPath, {
-            decodeArray: true,
-            disableCache: o.disableCache,
-          });
-          if (!x) {
-            console.log({
-              i1StartChunk,
-              i1EndChunk,
-              i2StartChunk,
-              i2EndChunk,
-              i1Start,
-              i1End,
-              i2Start,
-              i2End,
-              shape,
-              chunkShape,
-            });
-            throw Error("Unable to read chunk: " + chunkPath);
-          }
-          const j1Start = i1Start - i1StartChunk * chunkShape[0];
-          const j1End = i1End - i1StartChunk * chunkShape[0];
-          const j2Start = i2Start - i2StartChunk * chunkShape2;
-          const j2End = i2End - i2StartChunk * chunkShape2;
-          const slicingInSecondDimension =
-            ndims > 1 && (j2Start > 0 || j2End < chunkShape2);
-          if (!slicingInSecondDimension) {
-            // we are not slicing in second dimension. In this case we don't need to make a copy of the data
-            const ret0 = x.slice(
-              j1Start * prodChunkSizeOfAllButFirstDimension,
-              j1End * prodChunkSizeOfAllButFirstDimension,
-            );
-            retList.push(ret0);
-          } else {
-            // we are slicing in second dimension, so we need to make a copy of the data
-            const ret0 = allocateArrayWithDtype(
-              (i1End - i1Start) *
-                (i2End - i2Start) *
-                prodChunkSizeOfAllButFirstTwoDimensions,
-              dtype,
-            );
-            let iRet0 = 0;
-            for (let j1 = j1Start; j1 < j1End; j1++) {
-              for (let j2 = j2Start; j2 < j2End; j2++) {
-                for (
-                  let j3 = 0;
-                  j3 < prodChunkSizeOfAllButFirstTwoDimensions;
-                  j3++
-                ) {
-                  ret0[iRet0] =
-                    x[
-                      (j1 * chunkShape2 + j2) *
-                        prodChunkSizeOfAllButFirstTwoDimensions +
-                        j3
-                    ];
-                  iRet0++;
-                }
-              }
-            }
-            retList.push(ret0);
-          }
-        }
-      }
-      // now concatenate the ret0s
-      const ret = allocateArrayWithDtype(
-        (i1End - i1Start) *
-          (i2End - i2Start) *
-          prodShapeSizeOfAllButFirstTwoDimensions,
-        dtype,
+      return x;
+    };
+
+    const chunkLayoutMatchesArray =
+      j2Start === 0 &&
+      n2 === chunkShape2 &&
+      prodMacroChunkShapeAllButFirstTwoDimensions === 1 &&
+      trailingChunkShape.every((cs, d) => cs === trailingShape[d]);
+    if (chunkLayoutMatchesArray) {
+      // Every row of the chunk along the first dimension is laid out exactly
+      // like a row of the output, so a contiguous slice is enough.
+      const x = await readChunk(trailingChunkShape.map(() => 0));
+      return x.slice(
+        j1Start * prodChunkSizeOfAllButFirstDimension,
+        (j1Start + n1) * prodChunkSizeOfAllButFirstDimension,
       );
-      let iRet = 0;
-      for (let i1 = 0; i1 < i1End - i1Start; i1++) {
-        for (let i2 = 0; i2 < i2End - i2Start; i2++) {
-          for (let i = 0; i < retList.length; i++) {
-            for (
-              let i3 = 0;
-              i3 < prodChunkSizeOfAllButFirstTwoDimensions;
-              i3++
-            ) {
-              ret[iRet] =
-                retList[i][
-                  i1 *
-                    (i2End - i2Start) *
-                    prodChunkSizeOfAllButFirstTwoDimensions +
-                    i2 * prodChunkSizeOfAllButFirstTwoDimensions +
-                    i3
-                ];
-              iRet++;
+    }
+
+    const ret = allocateArrayWithDtype(
+      n1 * n2 * prodShapeSizeOfAllButFirstTwoDimensions,
+      dtype,
+    );
+    const numTrailingChunks = prodMacroChunkShapeAllButFirstTwoDimensions;
+    for (let ci = 0; ci < numTrailingChunks; ci++) {
+      const trailingChunkIndex = unravelIndex(ci, trailingMacroChunkShape);
+      const x = await readChunk(trailingChunkIndex);
+      // The extent of this chunk that lies inside the array, and where it
+      // starts along each trailing dimension.
+      const validExtent = trailingChunkIndex.map((c, d) =>
+        Math.min(
+          trailingChunkShape[d],
+          trailingShape[d] - c * trailingChunkShape[d],
+        ),
+      );
+      const trailingOffset = trailingChunkIndex.map(
+        (c, d) => c * trailingChunkShape[d],
+      );
+      if (numTrailingDims === 0) {
+        for (let j1 = 0; j1 < n1; j1++) {
+          for (let j2 = 0; j2 < n2; j2++) {
+            ret[j1 * n2 + j2] =
+              x[(j1Start + j1) * chunkShape2 + (j2Start + j2)];
+          }
+        }
+        continue;
+      }
+      // The last trailing dimension is contiguous in both the chunk and the
+      // output, so copy it as runs; walk every combination of the other
+      // trailing indices.
+      const runLength = validExtent[numTrailingDims - 1];
+      const outerExtent = validExtent.slice(0, numTrailingDims - 1);
+      const numRuns = outerExtent.reduce((a, b) => a * b, 1);
+      const lastOffset = trailingOffset[numTrailingDims - 1];
+      for (let r = 0; r < numRuns; r++) {
+        const outerIndex = unravelIndex(r, outerExtent);
+        let inOffset = 0;
+        let outOffset = lastOffset;
+        for (let d = 0; d < numTrailingDims - 1; d++) {
+          inOffset += outerIndex[d] * chunkStrides[d];
+          outOffset += (outerIndex[d] + trailingOffset[d]) * outStrides[d];
+        }
+        for (let j1 = 0; j1 < n1; j1++) {
+          for (let j2 = 0; j2 < n2; j2++) {
+            const inBase =
+              ((j1Start + j1) * chunkShape2 + (j2Start + j2)) *
+                prodChunkSizeOfAllButFirstTwoDimensions +
+              inOffset;
+            const outBase =
+              (j1 * n2 + j2) * prodShapeSizeOfAllButFirstTwoDimensions +
+              outOffset;
+            for (let k = 0; k < runLength; k++) {
+              ret[outBase + k] = x[inBase + k];
             }
           }
         }
       }
-      return ret;
     }
+    return ret;
   }
 
   if (assertSingleChunkInFirstTwoDimensions)
@@ -436,6 +372,26 @@ const lindiDatasetDataLoader = async (o: {
   }
   await Promise.all(promises);
   return ret;
+};
+
+// Strides of a row-major (C order) array with the given shape.
+const rowMajorStrides = (shape: number[]): number[] => {
+  const strides = new Array(shape.length).fill(1);
+  for (let d = shape.length - 2; d >= 0; d--) {
+    strides[d] = strides[d + 1] * shape[d + 1];
+  }
+  return strides;
+};
+
+// Multi-index of flat position i in a row-major array with the given shape.
+const unravelIndex = (i: number, shape: number[]): number[] => {
+  const index = new Array(shape.length).fill(0);
+  let rem = i;
+  for (let d = shape.length - 1; d >= 0; d--) {
+    index[d] = rem % shape[d];
+    rem = Math.floor(rem / shape[d]);
+  }
+  return index;
 };
 
 const allocateArrayWithDtype = (size: number, dtype: string) => {


### PR DESCRIPTION
Fixes #452.

When a slice lies within one chunk in the first two dimensions but the array has several chunks along the remaining dimensions, `lindiDatasetDataLoader` concatenated each chunk's full trailing extent into output rows that are sized for the array's trailing extent. If the trailing shape was not an exact multiple of the chunk shape, the last chunk's padding was copied in and every subsequent row shifted. For 4-D arrays with more than one chunk along the third dimension the chunks were appended instead of interleaved, so the order was wrong even with an exact division. The single trailing chunk fast path returned chunk-length rows when the chunk was padded past the array edge.

The trailing dimension copy is now done per chunk into its own region of the output using the array strides, restricted to the portion of the chunk that lies inside the array, and generalized to any number of trailing dimensions. The contiguous fast path is kept only when the chunk layout matches the array layout exactly, which is the common 1-D and 2-D case.

The new `lindiDatasetDataLoader.test.ts` builds an in-memory chunk store whose values are their flat index, with zero padded edge chunks as HDF5 and zarr store them, and checks reads against values computed directly from the index formula: 1-D and 2-D across chunks, the contiguous fast path, a padded single trailing chunk, exact and partial trailing chunks, two trailing chunked dimensions with padding, a 4-D array chunked in every dimension, and the three-dimension slice path. Seven of the eleven cases fail on the previous loader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c