### PR TITLE
Convert 64-bit integer datasets to Float64Array instead of Int32Array

### DIFF
--- a/src/remote-h5-file/lib/RemoteH5File.ts
+++ b/src/remote-h5-file/lib/RemoteH5File.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Canceler, postRemoteH5WorkerRequest } from "./helpers";
+import { bigIntArrayToFloat64, isBigIntArray } from "./bigIntArrayToFloat64";
 import RemoteH5FileLindi, {
   getRemoteH5FileLindi,
 } from "./lindi/RemoteH5FileLindi";
@@ -193,25 +194,8 @@ export class RemoteH5File {
     }
     const { data } = resp;
     let x = data;
-    if (!allowBigInt) {
-      // check if x is a BigInt64Array
-      if (x && x.constructor && x.constructor.name === "BigInt64Array") {
-        // convert to Int32Array
-        const y = new Int32Array(x.length);
-        for (let i = 0; i < x.length; i++) {
-          y[i] = Number(x[i]);
-        }
-        x = y;
-      }
-      // check if x is a BigUint64Array
-      if (x && x.constructor && x.constructor.name === "BigUint64Array") {
-        // convert to Uint32Array
-        const y = new Uint32Array(x.length);
-        for (let i = 0; i < x.length; i++) {
-          y[i] = Number(x[i]);
-        }
-        x = y;
-      }
+    if (!allowBigInt && isBigIntArray(x)) {
+      x = bigIntArrayToFloat64(x);
     }
     globalRemoteH5FileStats.getDatasetDataCount++;
     return x;

--- a/src/remote-h5-file/lib/bigIntArrayToFloat64.test.ts
+++ b/src/remote-h5-file/lib/bigIntArrayToFloat64.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { bigIntArrayToFloat64, isBigIntArray } from "./bigIntArrayToFloat64";
+
+describe("bigIntArrayToFloat64", () => {
+  it("keeps values beyond 32 bits exact", () => {
+    const x = new BigInt64Array([
+      0n,
+      -1n,
+      3000000000n,
+      -3000000000n,
+      2n ** 53n,
+      1700000000123456789n,
+    ]);
+    const y = bigIntArrayToFloat64(x);
+    expect(y).toBeInstanceOf(Float64Array);
+    expect(Array.from(y)).toEqual([
+      0,
+      -1,
+      3000000000,
+      -3000000000,
+      2 ** 53,
+      Number(1700000000123456789n),
+    ]);
+  });
+
+  it("converts unsigned 64-bit values", () => {
+    const x = new BigUint64Array([0n, 4294967296n, 2n ** 53n]);
+    expect(Array.from(bigIntArrayToFloat64(x))).toEqual([
+      0,
+      4294967296,
+      2 ** 53,
+    ]);
+  });
+
+  it("recognizes only BigInt typed arrays", () => {
+    expect(isBigIntArray(new BigInt64Array(1))).toBe(true);
+    expect(isBigIntArray(new BigUint64Array(1))).toBe(true);
+    expect(isBigIntArray(new Int32Array(1))).toBe(false);
+    expect(isBigIntArray(new Float64Array(1))).toBe(false);
+    expect(isBigIntArray([1n])).toBe(false);
+    expect(isBigIntArray(undefined)).toBe(false);
+  });
+});

--- a/src/remote-h5-file/lib/bigIntArrayToFloat64.ts
+++ b/src/remote-h5-file/lib/bigIntArrayToFloat64.ts
@@ -1,0 +1,20 @@
+// 64-bit integer datasets arrive as BigInt64Array or BigUint64Array. The rest
+// of the app does arithmetic with regular numbers, so they are converted to
+// Float64Array, which represents every integer up to 2^53 exactly. Converting
+// to Int32Array or Uint32Array, as was done before, silently wrapped any value
+// beyond 32 bits, such as nanosecond timestamps or large sample indices.
+export const bigIntArrayToFloat64 = (
+  x: BigInt64Array | BigUint64Array,
+): Float64Array => {
+  const y = new Float64Array(x.length);
+  for (let i = 0; i < x.length; i++) {
+    y[i] = Number(x[i]);
+  }
+  return y;
+};
+
+export const isBigIntArray = (
+  x: unknown,
+): x is BigInt64Array | BigUint64Array => {
+  return x instanceof BigInt64Array || x instanceof BigUint64Array;
+};

--- a/src/remote-h5-file/lib/lindi/int64Decoding.test.ts
+++ b/src/remote-h5-file/lib/lindi/int64Decoding.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The loader's module graph reaches the worker-backed HDF5 reader, which
+// creates a web worker at import time, so stub it out for node.
+vi.stubGlobal(
+  "Worker",
+  class {
+    postMessage() {}
+    addEventListener() {}
+    removeEventListener() {}
+    terminate() {}
+  },
+);
+if (typeof URL.createObjectURL !== "function") {
+  URL.createObjectURL = () => "blob:stub";
+}
+const { default: zarrDecodeChunkArray } =
+  await import("./zarrDecodeChunkArray");
+const { default: lindiDatasetDataLoader } =
+  await import("./lindiDatasetDataLoader");
+
+// Values that do not fit in 32 bits, like nanosecond timestamps.
+const bigValues = [0n, 2147483648n, -2147483649n, 3000000000n, 2n ** 53n];
+const bigNumbers = bigValues.map((v) => Number(v));
+
+describe("zarrDecodeChunkArray with 64-bit integers", () => {
+  it("decodes <i8 chunks to Float64Array without wrapping", async () => {
+    const buf = new BigInt64Array(bigValues).buffer;
+    const out = await zarrDecodeChunkArray(buf, "<i8", undefined, undefined, [
+      bigValues.length,
+    ]);
+    expect(out).toBeInstanceOf(Float64Array);
+    expect(Array.from(out)).toEqual(bigNumbers);
+  });
+
+  it("decodes <u8 chunks to Float64Array without wrapping", async () => {
+    const values = [0n, 4294967296n, 2n ** 53n];
+    const buf = new BigUint64Array(values).buffer;
+    const out = await zarrDecodeChunkArray(buf, "<u8", undefined, undefined, [
+      values.length,
+    ]);
+    expect(out).toBeInstanceOf(Float64Array);
+    expect(Array.from(out)).toEqual(values.map((v) => Number(v)));
+  });
+});
+
+describe("lindiDatasetDataLoader with 64-bit integers", () => {
+  it("reads a contiguous single-chunk <i8 dataset by byte range as numbers", async () => {
+    // No compressor and one chunk, so the loader fetches a byte range and
+    // interprets it directly. Previously this returned a BigInt64Array.
+    const values = new BigInt64Array(bigValues);
+    const client = {
+      readBinary: async (
+        path: string,
+        o: { decodeArray?: boolean; startByte?: number; endByte?: number },
+      ) => {
+        expect(path).toBe("t/0");
+        expect(o.decodeArray).toBe(false);
+        return values.buffer.slice(o.startByte ?? 0, o.endByte);
+      },
+    };
+    const out = await lindiDatasetDataLoader({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      path: "t",
+      zarray: { shape: [5], chunks: [5], dtype: "<i8", zarr_format: 2 },
+      slice: [[1, 4]],
+    });
+    expect(out).toBeInstanceOf(Float64Array);
+    expect(Array.from(out as Float64Array)).toEqual(bigNumbers.slice(1, 4));
+  });
+
+  it("reads a 2-D contiguous <i8 dataset sliced in both dimensions", async () => {
+    // Previously this path threw when assigning a BigInt into an Int32Array.
+    const shape = [4, 3];
+    const values = new BigInt64Array(12);
+    for (let i = 0; i < 12; i++) values[i] = 3000000000n + BigInt(i);
+    const client = {
+      readBinary: async (
+        _path: string,
+        o: { startByte?: number; endByte?: number },
+      ) => values.buffer.slice(o.startByte ?? 0, o.endByte),
+    };
+    const out = await lindiDatasetDataLoader({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      path: "t",
+      zarray: { shape, chunks: shape, dtype: "<i8", zarr_format: 2 },
+      slice: [
+        [1, 3],
+        [0, 2],
+      ],
+    });
+    expect(out).toBeInstanceOf(Float64Array);
+    expect(Array.from(out as Float64Array)).toEqual(
+      [3, 4, 6, 7].map((i) => 3000000000 + i),
+    );
+  });
+
+  it("assembles <i8 data across chunks without wrapping", async () => {
+    // Two chunks along the first dimension exercise the allocate-and-copy
+    // path, which used to allocate an Int32Array for <i8.
+    const shape = [4];
+    const chunks: { [path: string]: Float64Array } = {
+      "t/0": new Float64Array([3000000000, 3000000001]),
+      "t/1": new Float64Array([3000000002, 3000000003]),
+    };
+    const client = {
+      readBinary: async (path: string) => chunks[path],
+    };
+    const out = await lindiDatasetDataLoader({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client: client as any,
+      path: "t",
+      zarray: {
+        shape,
+        chunks: [2],
+        dtype: "<i8",
+        zarr_format: 2,
+        compressor: { id: "zlib" },
+      },
+      slice: [[1, 4]],
+    });
+    expect(out).toBeInstanceOf(Float64Array);
+    expect(Array.from(out as Float64Array)).toEqual([
+      3000000001, 3000000002, 3000000003,
+    ]);
+  });
+});

--- a/src/remote-h5-file/lib/lindi/lindiDatasetDataLoader.ts
+++ b/src/remote-h5-file/lib/lindi/lindiDatasetDataLoader.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { bigIntArrayToFloat64 } from "../bigIntArrayToFloat64";
 import ReferenceFileSystemClient from "./ReferenceFileSystemClient";
 import { ZarrFileSystemClient, ZMetaDataZArray } from "./RemoteH5FileLindi";
 
@@ -444,27 +445,12 @@ const allocateArrayWithDtype = (size: number, dtype: string) => {
   if (dtype === "<i1" || dtype === "|i1") return new Int8Array(size);
   if (dtype === "<i2") return new Int16Array(size);
   if (dtype === "<i4") return new Int32Array(size);
-  if (dtype === "<i8") {
-    const a = new BigInt64Array(size);
-    // convert to regular Int32Array because js has trouble mixing BigInt64Array with other numbers
-    const ret = new Int32Array(size);
-    for (let i = 0; i < size; i++) {
-      ret[i] = Number(a[i]);
-    }
-    return ret;
-  }
+  // 64-bit integers are carried as Float64Array, see bigIntArrayToFloat64.
+  if (dtype === "<i8") return new Float64Array(size);
   if (dtype === "<u1" || dtype === "|u1") return new Uint8Array(size);
   if (dtype === "<u2") return new Uint16Array(size);
   if (dtype === "<u4") return new Uint32Array(size);
-  if (dtype === "<u8") {
-    const a = new BigUint64Array(size);
-    // convert to regular Uint32Array because js has trouble mixing BigUint64Array with other numbers
-    const ret = new Uint32Array(size);
-    for (let i = 0; i < size; i++) {
-      ret[i] = Number(a[i]);
-    }
-    return ret;
-  }
+  if (dtype === "<u8") return new Float64Array(size);
   if (dtype === "|O") return new Array(size);
   throw Error(`Unsupported dtype: ${dtype}`);
 };
@@ -475,11 +461,11 @@ const createDataView = (dd: ArrayBuffer, dtype: string) => {
   if (dtype === "<i1" || dtype === "|i1") return new Int8Array(dd);
   if (dtype === "<i2") return new Int16Array(dd);
   if (dtype === "<i4") return new Int32Array(dd);
-  if (dtype === "<i8") return new BigInt64Array(dd);
+  if (dtype === "<i8") return bigIntArrayToFloat64(new BigInt64Array(dd));
   if (dtype === "<u1" || dtype === "|u1") return new Uint8Array(dd);
   if (dtype === "<u2") return new Uint16Array(dd);
   if (dtype === "<u4") return new Uint32Array(dd);
-  if (dtype === "<u8") return new BigUint64Array(dd);
+  if (dtype === "<u8") return bigIntArrayToFloat64(new BigUint64Array(dd));
   throw Error(`Unsupported dtype: ${dtype}`);
 };
 

--- a/src/remote-h5-file/lib/lindi/zarrDecodeChunkArray.ts
+++ b/src/remote-h5-file/lib/lindi/zarrDecodeChunkArray.ts
@@ -1,6 +1,7 @@
 import { Blosc } from "numcodecs";
 import pako from "pako";
 import { qfcDecompress } from "./qfc";
+import { bigIntArrayToFloat64 } from "../bigIntArrayToFloat64";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const zarrDecodeChunkArray = async (
@@ -69,12 +70,7 @@ const zarrDecodeChunkArray = async (
     } else if (dtype === "<i4") {
       ret = new Int32Array(ret);
     } else if (dtype === "<i8") {
-      const ret0 = new BigInt64Array(ret);
-      // convert to Int32Array because javascript has trouble mixing BigInt64Array with other types
-      ret = new Int32Array(ret0.length);
-      for (let i = 0; i < ret0.length; i++) {
-        ret[i] = Number(ret0[i]);
-      }
+      ret = bigIntArrayToFloat64(new BigInt64Array(ret));
     } else if (dtype === "<u1" || dtype === "|u1") {
       ret = new Uint8Array(ret);
     } else if (dtype === "<u2") {
@@ -82,12 +78,7 @@ const zarrDecodeChunkArray = async (
     } else if (dtype === "<u4") {
       ret = new Uint32Array(ret);
     } else if (dtype === "<u8") {
-      const ret0 = new BigUint64Array(ret);
-      // convert to Uint32Array because javascript has trouble mixing BigUint64Array with other types
-      ret = new Uint32Array(ret0.length);
-      for (let i = 0; i < ret0.length; i++) {
-        ret[i] = Number(ret0[i]);
-      }
+      ret = bigIntArrayToFloat64(new BigUint64Array(ret));
     } else if (dtype === "|b1") {
       ret = new Uint8Array(ret);
     } else if (dtype.startsWith("<U")) {


### PR DESCRIPTION
Fixes #454.

int64 and uint64 datasets were converted from BigInt64Array or BigUint64Array into Int32Array or Uint32Array at three sites: `getDatasetData` in `RemoteH5File.ts`, the `<i8` and `<u8` branches of `zarrDecodeChunkArray.ts`, and `allocateArrayWithDtype` in `lindiDatasetDataLoader.ts`. Values outside the 32-bit range wrapped silently, so nanosecond timestamps and large indices came through corrupted. The LINDI contiguous single-chunk path was the odd one out and returned a BigInt64Array from `createDataView`, which made 1-D callers throw on arithmetic and 2-D slices throw when a BigInt was assigned into an Int32Array.

All of these now use a shared `bigIntArrayToFloat64` helper. Float64 represents every integer up to 2^53 exactly, and the consumers of dataset data (the value renderers, the dynamic table, the chunking clients) already accept Float64Array. No caller passes `allowBigInt: true`, so that option keeps its meaning and behavior.

Tests: `bigIntArrayToFloat64.test.ts` checks exactness beyond 32 bits for signed and unsigned input and the type guard; `int64Decoding.test.ts` checks the two decoder branches, the loader's byte-range path in 1-D and 2-D, and the loader's chunked path. All five decoding tests fail on the previous code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c