### PR TITLE
Harden the local file server

### DIFF
--- a/.github/workflows/test-neurosift-package.yml
+++ b/.github/workflows/test-neurosift-package.yml
@@ -171,6 +171,12 @@ jobs:
             test_neurosift_cli()
         EOF
 
+    - name: Test the local file server
+      run: |
+        cd python/neurosift/local-file-access-js
+        npm install
+        npm test
+
     - name: Test neurosift CLI help
       run: |
         neurosift --help

--- a/python/neurosift/local-file-access-js/package.json
+++ b/python/neurosift/local-file-access-js/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "start": "node src/index.js",
-    "start2": "node src/index.js --jupyter-url $JUPYTER_URL --allow-origin $ALLOW_ORIGIN --port $PORT"
+    "start2": "node src/index.js --jupyter-url $JUPYTER_URL --allow-origin $ALLOW_ORIGIN --port $PORT",
+    "test": "node --test spec/*.test.js"
   }
 }

--- a/python/neurosift/local-file-access-js/spec/server.test.js
+++ b/python/neurosift/local-file-access-js/spec/server.test.js
@@ -1,0 +1,236 @@
+// Starts the file server on a temporary directory and exercises it over HTTP.
+// Run with: npm test
+const assert = require('node:assert/strict')
+const { spawn } = require('node:child_process')
+const fs = require('node:fs')
+const http = require('node:http')
+const net = require('node:net')
+const os = require('node:os')
+const path = require('node:path')
+const { after, before, describe, it } = require('node:test')
+
+const freePort = () =>
+    new Promise((resolve, reject) => {
+        const s = net.createServer()
+        s.listen(0, '127.0.0.1', () => {
+            const { port } = s.address()
+            s.close(() => resolve(port))
+        })
+        s.on('error', reject)
+    })
+
+// Raw request so that paths like /files/../x reach the server unnormalized.
+const request = (port, rawPath, { method = 'GET', headers = {} } = {}) =>
+    new Promise((resolve, reject) => {
+        const req = http.request(
+            { host: '127.0.0.1', port, path: rawPath, method, headers },
+            (res) => {
+                const chunks = []
+                res.on('data', (c) => chunks.push(c))
+                res.on('end', () =>
+                    resolve({ status: res.statusCode, headers: res.headers, body: Buffer.concat(chunks) }),
+                )
+            },
+        )
+        req.on('error', reject)
+        req.end()
+    })
+
+const waitForServer = async (port, child) => {
+    for (let i = 0; i < 100; i++) {
+        if (child.exitCode !== null) throw new Error(`server exited with ${child.exitCode}`)
+        try {
+            await request(port, '/files/does-not-matter')
+            return
+        }
+        catch {
+            await new Promise((r) => setTimeout(r, 50))
+        }
+    }
+    throw new Error('server did not start')
+}
+
+describe('local file server', () => {
+    let tmp
+    let port
+    let child
+    let stderr = ''
+    const content = Buffer.alloc(1000)
+    for (let i = 0; i < content.length; i++) content[i] = i % 251
+
+    before(async () => {
+        tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'neurosift-server-'))
+        fs.writeFileSync(path.join(tmp, 'a.bin'), content)
+        fs.writeFileSync(path.join(tmp, '.zattrs'), '{}')
+        fs.writeFileSync(path.join(tmp, '.hidden'), 'secret')
+        fs.mkdirSync(path.join(tmp, 'sub'))
+        fs.writeFileSync(path.join(tmp, 'sub', 'b.bin'), 'bbb')
+        // Something outside the served directory that must stay unreachable.
+        fs.writeFileSync(path.join(path.dirname(tmp), path.basename(tmp) + '-outside.txt'), 'outside')
+        port = await freePort()
+        child = spawn(process.execPath, [path.join(__dirname, '..', 'src', 'index.js'), tmp], {
+            env: { ...process.env, PORT: String(port) },
+            stdio: ['ignore', 'ignore', 'pipe'],
+        })
+        child.stderr.on('data', (d) => { stderr += d.toString() })
+        await waitForServer(port, child)
+    })
+
+    after(() => {
+        if (child && child.exitCode === null) child.kill()
+        fs.rmSync(tmp, { recursive: true, force: true })
+        fs.rmSync(path.join(path.dirname(tmp), path.basename(tmp) + '-outside.txt'), { force: true })
+    })
+
+    const assertAlive = async () => {
+        assert.equal(child.exitCode, null, `server exited\n${stderr}`)
+        const r = await request(port, '/files/a.bin', { headers: { range: 'bytes=0-0' } })
+        assert.equal(r.status, 206)
+    }
+
+    it('serves a whole file', async () => {
+        const r = await request(port, '/files/a.bin')
+        assert.equal(r.status, 200)
+        assert.equal(r.headers['content-length'], '1000')
+        assert.equal(r.headers['accept-ranges'], 'bytes')
+        assert.ok(r.body.equals(content))
+    })
+
+    it('serves a file in a subdirectory', async () => {
+        const r = await request(port, '/files/sub/b.bin')
+        assert.equal(r.status, 200)
+        assert.equal(r.body.toString(), 'bbb')
+    })
+
+    it('serves a closed byte range', async () => {
+        const r = await request(port, '/files/a.bin', { headers: { range: 'bytes=10-19' } })
+        assert.equal(r.status, 206)
+        assert.equal(r.headers['content-range'], 'bytes 10-19/1000')
+        assert.equal(r.headers['content-length'], '10')
+        assert.ok(r.body.equals(content.subarray(10, 20)))
+    })
+
+    it('serves an open-ended byte range', async () => {
+        const r = await request(port, '/files/a.bin', { headers: { range: 'bytes=990-' } })
+        assert.equal(r.status, 206)
+        assert.equal(r.headers['content-range'], 'bytes 990-999/1000')
+        assert.ok(r.body.equals(content.subarray(990)))
+    })
+
+    it('serves a suffix byte range', async () => {
+        const r = await request(port, '/files/a.bin', { headers: { range: 'bytes=-10' } })
+        assert.equal(r.status, 206)
+        assert.equal(r.headers['content-range'], 'bytes 990-999/1000')
+        assert.ok(r.body.equals(content.subarray(990)))
+    })
+
+    it('clamps a range that runs past the end of the file', async () => {
+        const r = await request(port, '/files/a.bin', { headers: { range: 'bytes=0-5000' } })
+        assert.equal(r.status, 206)
+        assert.equal(r.headers['content-range'], 'bytes 0-999/1000')
+        assert.equal(r.headers['content-length'], '1000')
+        assert.equal(r.body.length, 1000)
+    })
+
+    it('answers 416 for a range beyond the file', async () => {
+        const r = await request(port, '/files/a.bin', { headers: { range: 'bytes=2000-3000' } })
+        assert.equal(r.status, 416)
+        assert.equal(r.headers['content-range'], 'bytes */1000')
+        await assertAlive()
+    })
+
+    it('answers 416 for an inverted range', async () => {
+        const r = await request(port, '/files/a.bin', { headers: { range: 'bytes=50-10' } })
+        assert.equal(r.status, 416)
+    })
+
+    it('ignores a malformed Range header and sends the whole file', async () => {
+        const r = await request(port, '/files/a.bin', { headers: { range: 'bytes=abc' } })
+        assert.equal(r.status, 200)
+        assert.equal(r.body.length, 1000)
+    })
+
+    it('answers HEAD with headers and no body', async () => {
+        const r = await request(port, '/files/a.bin', { method: 'HEAD' })
+        assert.equal(r.status, 200)
+        assert.equal(r.headers['content-length'], '1000')
+        assert.equal(r.body.length, 0)
+        const r2 = await request(port, '/files/a.bin', { method: 'HEAD', headers: { range: 'bytes=0-9' } })
+        assert.equal(r2.status, 206)
+        assert.equal(r2.headers['content-range'], 'bytes 0-9/1000')
+        assert.equal(r2.body.length, 0)
+    })
+
+    it('refuses parent directory traversal and keeps running', async () => {
+        const outside = path.basename(tmp) + '-outside.txt'
+        const r = await request(port, `/files/../${outside}`)
+        assert.equal(r.status, 403)
+        assert.ok(!r.body.toString().includes('outside'))
+        const r2 = await request(port, `/files/sub/../../${outside}`)
+        assert.equal(r2.status, 403)
+        const r3 = await request(port, `/files/%2e%2e/${outside}`)
+        assert.equal(r3.status, 403)
+        await assertAlive()
+    })
+
+    it('refuses backslash traversal', async () => {
+        const outside = path.basename(tmp) + '-outside.txt'
+        const r = await request(port, `/files/sub%5C..%5C..%5C${outside}`)
+        // 403 where backslash is a separator (Windows); 404 elsewhere, where
+        // it is an ordinary character in a file name that does not exist.
+        assert.ok([403, 404].includes(r.status), String(r.status))
+        assert.ok(!r.body.toString().includes('outside'))
+        await assertAlive()
+    })
+
+    it('hides dot files except the zarr metadata files', async () => {
+        const r = await request(port, '/files/.hidden')
+        assert.equal(r.status, 403)
+        const r2 = await request(port, '/files/.zattrs')
+        assert.equal(r2.status, 200)
+        assert.equal(r2.body.toString(), '{}')
+    })
+
+    it('answers 404 for a missing file', async () => {
+        const r = await request(port, '/files/missing.bin')
+        assert.equal(r.status, 404)
+        const r2 = await request(port, '/files/a.bin/child')
+        assert.equal(r2.status, 404)
+    })
+
+    it('answers 404 for a directory and keeps running', async () => {
+        const r = await request(port, '/files/sub')
+        assert.equal(r.status, 404)
+        await assertAlive()
+    })
+
+    it('allows only known origins', async () => {
+        const ok = await request(port, '/files/a.bin', { method: 'HEAD', headers: { origin: 'https://neurosift.app' } })
+        assert.equal(ok.headers['access-control-allow-origin'], 'https://neurosift.app')
+        const dev = await request(port, '/files/a.bin', { method: 'HEAD', headers: { origin: 'http://localhost:5173' } })
+        assert.equal(dev.headers['access-control-allow-origin'], 'http://localhost:5173')
+        const preview = await request(port, '/files/a.bin', { method: 'HEAD', headers: { origin: 'https://my-branch.neurosift.pages.dev' } })
+        assert.equal(preview.headers['access-control-allow-origin'], 'https://my-branch.neurosift.pages.dev')
+        const bad = await request(port, '/files/a.bin', { method: 'HEAD', headers: { origin: 'https://evil.example' } })
+        assert.equal(bad.headers['access-control-allow-origin'], undefined)
+    })
+
+    it('listens on loopback only', async () => {
+        const addresses = Object.values(os.networkInterfaces())
+            .flat()
+            .filter((a) => a && !a.internal && a.family === 'IPv4')
+            .map((a) => a.address)
+        for (const address of addresses) {
+            await assert.rejects(
+                new Promise((resolve, reject) => {
+                    const s = net.connect({ host: address, port, timeout: 1000 })
+                    s.on('connect', () => { s.destroy(); resolve() })
+                    s.on('timeout', () => { s.destroy(); reject(new Error('timeout')) })
+                    s.on('error', reject)
+                }),
+                undefined,
+                `connected via ${address}`,
+            )
+        }
+    })
+})

--- a/python/neurosift/local-file-access-js/src/index.js
+++ b/python/neurosift/local-file-access-js/src/index.js
@@ -1,19 +1,30 @@
 const express = require('express')
+const fs = require('fs')
+const http = require('http')
+const path = require('path')
+
 const app = express()
 const port = process.env.PORT || 61762
-const dir = process.argv[2]
-const fs = require('fs')
-if (!dir) {
+const dirArg = process.argv[2]
+if (!dirArg) {
     console.error('Please specify a directory.')
     process.exit(-1)
 }
+// Resolve once so that every served path can be checked against it.
+const dir = path.resolve(dirArg)
 console.info('Serving files in', dir)
 
 // Allowed CORS origins. Exact-match list plus a pattern for Cloudflare Pages
 // preview deploys of this repo (every branch is published as
 // <branch>.neurosift.pages.dev), so `view-nwb --neurosift-url <preview>` works
 // without an allowlist edit per branch.
-const allowedOrigins = ['https://neurosift.app', 'https://flatironinstitute.github.io', 'http://localhost:3000', 'http://localhost:4200']
+const allowedOrigins = [
+    'https://neurosift.app',
+    'https://flatironinstitute.github.io',
+    'http://localhost:3000',
+    'http://localhost:4200',
+    'http://localhost:5173',
+]
 const allowedOriginPatterns = [/^https:\/\/[a-z0-9-]+\.neurosift\.pages\.dev$/]
 app.use((req, resp, next) => {
     const origin = req.get('origin')
@@ -24,6 +35,7 @@ app.use((req, resp, next) => {
     if (allowedOrigin) {
         resp.header('Access-Control-Allow-Origin', allowedOrigin)
         resp.header('Access-Control-Allow-Headers', "Origin, X-Requested-With, Content-Type, Accept, Range")
+        resp.header('Access-Control-Expose-Headers', "Content-Length, Content-Range, Accept-Ranges")
     }
     next()
 })
@@ -32,73 +44,159 @@ app.options('*', (req, resp) => {
     resp.sendStatus(200)
 })
 
-// Serve files
+// Parse a single-range Range header against a file of the given size.
+// Returns { start, end } for a satisfiable range, 'unsatisfiable' when the
+// range lies entirely outside the file, or undefined when the header should
+// be ignored (absent, malformed, or a multi-range request), in which case
+// the whole file is sent with a 200.
+function parseRange(rangeHeader, fileSize) {
+    if (!rangeHeader) return undefined
+    const m = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader.trim())
+    if (!m) return undefined
+    const [, startStr, endStr] = m
+    if (startStr === '' && endStr === '') return undefined
+    let start
+    let end
+    if (startStr === '') {
+        // suffix range: the last N bytes
+        const suffixLength = parseInt(endStr, 10)
+        if (suffixLength === 0) return 'unsatisfiable'
+        start = Math.max(0, fileSize - suffixLength)
+        end = fileSize - 1
+    }
+    else {
+        start = parseInt(startStr, 10)
+        end = endStr === '' ? fileSize - 1 : Math.min(parseInt(endStr, 10), fileSize - 1)
+    }
+    if (start >= fileSize || start > end) return 'unsatisfiable'
+    return { start, end }
+}
+
+// Map a requested file name to an absolute path inside the served directory,
+// or undefined if it escapes it or is a hidden file. path.resolve handles
+// '..' segments and, on Windows, backslashes, so a check on the resolved
+// path covers both.
+function resolveShareablePath(fileName) {
+    const fullFileName = path.resolve(dir, fileName)
+    if (fullFileName !== dir && !fullFileName.startsWith(dir + path.sep)) {
+        return undefined
+    }
+    const base = path.basename(fullFileName)
+    if (base.startsWith('.')) {
+        if (!['.zattrs', '.zgroup', '.zarray', '.zmetadata'].includes(base)) {
+            // don't show hidden files (with some exceptions)
+            return undefined
+        }
+    }
+    return fullFileName
+}
+
+// Serve files. Express runs GET handlers for HEAD as well.
 app.get('/files/:fileName(*)', async (req, resp) => {
     const fileName = req.params.fileName
-    // Check if the file is shareable
-    if (!isShareable(fileName)) {
+    const fullFileName = resolveShareablePath(fileName)
+    if (!fullFileName) {
         console.warn('Access to this file is forbidden.', fileName)
-        resp.send(500).send('Access to this file is forbidden.')
+        resp.status(403).type('text/plain').send('Access to this file is forbidden.')
         return
     }
 
+    let stats
     try {
-        const fullFileName = `${dir}/${fileName}`
-        const stats = await fs.promises.stat(fullFileName)
-        const fileSize = stats.size
-
-        const range = req.headers.range
-
-        if (range) {
-            const parts = range.replace(/bytes=/, "").split("-")
-            const start = parseInt(parts[0], 10)
-            const end = parts[1] ? parseInt(parts[1], 10) : fileSize - 1
-            const chunksize = (end - start) + 1
-            const file = fs.createReadStream(fullFileName, { start, end })
-            const head = {
-                'Content-Range': `bytes ${start}-${end}/${fileSize}`,
-                'Accept-Ranges': 'bytes',
-                'Content-Length': chunksize,
-                'Content-Type': 'application/octet-stream',
-            }
-            resp.writeHead(206, head)
-            file.pipe(resp)
-        }
-        else {
-            const head = {
-                'Content-Length': fileSize,
-                'Content-Type': 'application/octet-stream',
-            }
-            resp.writeHead(200, head)
-            fs.createReadStream(fullFileName).pipe(resp)
-        }
+        stats = await fs.promises.stat(fullFileName)
     }
     catch (err) {
-        console.error(err)
-        resp.sendStatus(500)
-    }
-})
-
-app.options('/files/:fileName(*)', async (req, resp) => {
-    resp.send(200)
-})
-
-function isShareable(f) {
-    const bb = f.split('/')
-    if (bb.includes('..')) {
-        // don't allow access to parent directories
-        return false
-    }
-    const fileName = bb[bb.length - 1]
-    if (fileName.startsWith('.')) {
-        if (!['.zattrs', '.zgroup', '.zarray', '.zmetadata'].includes(fileName)) {
-            // don't show hidden files (with some exceptions)
-            return false
+        if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
+            resp.status(404).type('text/plain').send('File not found.')
         }
+        else {
+            console.error(err)
+            resp.status(500).type('text/plain').send('Unable to read file.')
+        }
+        return
     }
-    return true
+    if (!stats.isFile()) {
+        resp.status(404).type('text/plain').send('File not found.')
+        return
+    }
+    const fileSize = stats.size
+
+    const range = parseRange(req.headers.range, fileSize)
+    if (range === 'unsatisfiable') {
+        resp.status(416).set({
+            'Content-Range': `bytes */${fileSize}`,
+            'Accept-Ranges': 'bytes',
+        }).end()
+        return
+    }
+
+    let status
+    let head
+    let streamOptions
+    if (range) {
+        const { start, end } = range
+        status = 206
+        head = {
+            'Content-Range': `bytes ${start}-${end}/${fileSize}`,
+            'Accept-Ranges': 'bytes',
+            'Content-Length': end - start + 1,
+            'Content-Type': 'application/octet-stream',
+        }
+        streamOptions = { start, end }
+    }
+    else {
+        status = 200
+        head = {
+            'Accept-Ranges': 'bytes',
+            'Content-Length': fileSize,
+            'Content-Type': 'application/octet-stream',
+        }
+        streamOptions = {}
+    }
+
+    if (req.method === 'HEAD') {
+        resp.writeHead(status, head)
+        resp.end()
+        return
+    }
+
+    const file = fs.createReadStream(fullFileName, streamOptions)
+    file.on('open', () => {
+        resp.writeHead(status, head)
+        file.pipe(resp)
+    })
+    file.on('error', (err) => {
+        console.error(err)
+        if (!resp.headersSent) {
+            resp.status(500).type('text/plain').send('Unable to read file.')
+        }
+        else {
+            resp.destroy()
+        }
+    })
+    resp.on('close', () => {
+        file.destroy()
+    })
+})
+
+// Listen on the loopback interfaces only. The CLI opens the browser at
+// http://localhost:<port>, which may resolve to either address family, so
+// both are bound when available; other hosts on the network get nothing.
+function listenLoopback(host) {
+    return new Promise((resolve) => {
+        const server = http.createServer(app)
+        server.once('error', (err) => {
+            console.warn(`Not listening on ${host}: ${err.code}`)
+            resolve(undefined)
+        })
+        server.listen(port, host, () => resolve(server))
+    })
 }
 
-app.listen(port, () => {
-    console.info(`Serving files in ${dir} on port ${port}.`)
-});
+Promise.all([listenLoopback('127.0.0.1'), listenLoopback('::1')]).then((servers) => {
+    if (!servers.some((s) => s)) {
+        console.error(`Unable to listen on port ${port}.`)
+        process.exit(1)
+    }
+    console.info(`Serving files in ${dir} on port ${port} (localhost only).`)
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
@@ -14,5 +14,11 @@ export default defineConfig({
       '@hdf5Interface': path.resolve(__dirname, './src/pages/NwbPage/hdf5Interface'),
       "@jobManager": path.resolve(__dirname, "./src/jobManager")
     }
-  }
+  },
+  test: {
+    // Only the front end's tests run here. The Python package's file server
+    // and the job runners carry their own node:test suites, which vitest
+    // would otherwise pick up and report as empty.
+    include: ['src/**/*.test.{ts,tsx}'],
+  },
 })


### PR DESCRIPTION
Fixes #458.

The file server started by `neurosift view-nwb` exited on any request for a forbidden path because `resp.send(500).send(...)` throws after the headers are sent, and on any request for a directory because the read stream had no error handler. Ranges that ran past the end of the file advertised a Content-Length larger than the bytes streamed, which hangs the client, suffix ranges produced NaN, missing files answered 500, and the server listened on all interfaces even though the CLI only opens localhost. The traversal check also missed backslash separators on Windows.

Changes in `src/index.js`: the request path is resolved with `path.resolve` and must stay inside the served directory, which covers `..`, encoded dots, and backslashes; responses use 403, 404, 416, and 500 as appropriate; the read stream gets an error handler and is destroyed when the client goes away; HEAD returns headers only; ranges are parsed with a strict pattern, clamped to the file, and suffix ranges are supported; the server binds 127.0.0.1 and ::1 only (both, since `localhost` can resolve to either); `Content-Range` and friends are exposed to CORS; and `http://localhost:5173` is allowed, matching the Python README.

Testing: `npm test` in `python/neurosift/local-file-access-js` runs `spec/server.test.js` with the built-in `node:test` runner. It spawns the server on a temporary directory and checks 17 cases: whole file, subdirectory, closed, open-ended, suffix, clamped, and unsatisfiable ranges, malformed Range, HEAD with and without a range, traversal through `..`, `sub/../..`, `%2e%2e`, and backslashes, dot file hiding with the zarr exceptions, 404 for missing files and directories, CORS origins, and that no non-loopback interface accepts a connection. After each rejected request the test confirms the server is still up. Against the previous server the suite hangs on the clamped-range case, which is the client-side symptom of that bug. The package CI workflow now runs the suite.

The test directory is named `spec` because `python/.gitignore` ignores anything starting with `test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c