### PR TITLE
Plot every event in LabeledEvents series

### DIFF
--- a/src/pages/NwbPage/plugins/simple-timeseries/LabeledEventsPlot.tsx
+++ b/src/pages/NwbPage/plugins/simple-timeseries/LabeledEventsPlot.tsx
@@ -1,6 +1,7 @@
 import { FunctionComponent, useEffect, useRef, useState } from "react";
 import Plot from "react-plotly.js";
 import { Data } from "plotly.js";
+import { distinctLabelValues, labeledEventPoints } from "./labeledEventsPoints";
 
 type Props = {
   timestamps?: number[];
@@ -62,10 +63,8 @@ const LabeledEventsPlot: FunctionComponent<Props> = ({
   // For labeled events, we want to create scatter plots where each unique value (label)
   // gets its own color and appears in the legend
   // Create a single trace with all points
-  const points = data.map((d, i) => ({
-    timestamp: timestamps[i],
-    value: d[0],
-  }));
+  const points = labeledEventPoints(timestamps, data);
+  const labelValues = distinctLabelValues(points);
 
   const trace: Data = {
     x: points.map((p) => p.timestamp),
@@ -112,13 +111,9 @@ const LabeledEventsPlot: FunctionComponent<Props> = ({
             showticklabels: true,
             showgrid: true,
             tickmode: "array",
-            tickvals: Array.from(new Set(points.map((p) => p.value))).sort(
-              (a, b) => a - b,
-            ),
-            ticktext: Array.from(new Set(points.map((p) => p.value)))
-              .sort((a, b) => a - b)
-              .map((v) => labels[v] || `Value ${v}`),
-            range: [-1, Array.from(new Set(points.map((p) => p.value))).length],
+            tickvals: labelValues,
+            ticktext: labelValues.map((v) => labels[v] || `Value ${v}`),
+            range: [-1, labelValues.length],
           },
           showlegend: false,
           hovermode: "closest",

--- a/src/pages/NwbPage/plugins/simple-timeseries/labeledEventsPoints.test.ts
+++ b/src/pages/NwbPage/plugins/simple-timeseries/labeledEventsPoints.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { distinctLabelValues, labeledEventPoints } from "./labeledEventsPoints";
+
+describe("labeledEventPoints", () => {
+  it("pairs every timestamp with the value from the single channel", () => {
+    const timestamps = [0.5, 1.0, 1.5, 2.0];
+    const data = [[2, 0, 1, 2]]; // channel-major: one channel
+    expect(labeledEventPoints(timestamps, data)).toEqual([
+      { timestamp: 0.5, value: 2 },
+      { timestamp: 1.0, value: 0 },
+      { timestamp: 1.5, value: 1 },
+      { timestamp: 2.0, value: 2 },
+    ]);
+  });
+
+  it("returns one point per event, not one per channel", () => {
+    const timestamps = Array.from({ length: 50 }, (_, i) => i * 0.1);
+    const data = [timestamps.map((_, i) => i % 3)];
+    expect(labeledEventPoints(timestamps, data)).toHaveLength(50);
+  });
+
+  it("handles empty input", () => {
+    expect(labeledEventPoints([], [])).toEqual([]);
+    expect(labeledEventPoints([], [[]])).toEqual([]);
+  });
+
+  it("truncates to the shorter of timestamps and values", () => {
+    expect(labeledEventPoints([0, 1, 2], [[5, 6]])).toEqual([
+      { timestamp: 0, value: 5 },
+      { timestamp: 1, value: 6 },
+    ]);
+  });
+});
+
+describe("distinctLabelValues", () => {
+  it("lists the label indices present in increasing order", () => {
+    const points = labeledEventPoints([0, 1, 2, 3, 4], [[3, 0, 3, 1, 0]]);
+    expect(distinctLabelValues(points)).toEqual([0, 1, 3]);
+  });
+});

--- a/src/pages/NwbPage/plugins/simple-timeseries/labeledEventsPoints.ts
+++ b/src/pages/NwbPage/plugins/simple-timeseries/labeledEventsPoints.ts
@@ -1,0 +1,25 @@
+export type LabeledEventPoint = {
+  timestamp: number;
+  value: number;
+};
+
+// Build the scatter points for a LabeledEvents series. The timeseries client
+// returns data channel-major, one array per channel, and a LabeledEvents
+// series has a single channel of integer label indices, so the points come
+// from data[0] paired with the timestamps.
+export const labeledEventPoints = (
+  timestamps: number[],
+  data: number[][],
+): LabeledEventPoint[] => {
+  const values = data[0] ?? [];
+  const n = Math.min(timestamps.length, values.length);
+  const points: LabeledEventPoint[] = [];
+  for (let i = 0; i < n; i++) {
+    points.push({ timestamp: timestamps[i], value: values[i] });
+  }
+  return points;
+};
+
+// The distinct label indices present in the points, in increasing order.
+export const distinctLabelValues = (points: LabeledEventPoint[]): number[] =>
+  Array.from(new Set(points.map((p) => p.value))).sort((a, b) => a - b);


### PR DESCRIPTION
Fixes #460.

`LabeledEventsPlot` mapped over the outer array of `data`, which the timeseries client returns channel-major. A LabeledEvents series has one channel, so the plot showed a single marker no matter how many events were in the visible window.

The point construction now lives in `labeledEventsPoints.ts`: `labeledEventPoints` pairs `data[0]` with the timestamps, and `distinctLabelValues` gives the sorted label indices used for the y-axis ticks (which previously computed the same set three times inline). Tests cover the pairing, the count (one point per event rather than per channel), empty input, and mismatched lengths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c