### PR TITLE
Apply channel separation once when computing the plot y-range

### DIFF
--- a/src/pages/NwbPage/plugins/simple-timeseries/timeseriesPlotMath.test.ts
+++ b/src/pages/NwbPage/plugins/simple-timeseries/timeseriesPlotMath.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import {
+  channelOffset,
+  computeAvgStdDev,
+  computeChannelRanges,
+  computeMax,
+  computeMin,
+  computeYRange,
+} from "./timeseriesPlotMath";
+
+describe("computeMin / computeMax", () => {
+  it("skip NaN samples", () => {
+    expect(computeMin([NaN, 3, -2, NaN, 5])).toBe(-2);
+    expect(computeMax([NaN, 3, -2, NaN, 5])).toBe(5);
+  });
+  it("return infinities for an all-NaN channel", () => {
+    expect(computeMin([NaN, NaN])).toBe(Infinity);
+    expect(computeMax([NaN, NaN])).toBe(-Infinity);
+  });
+});
+
+describe("computeAvgStdDev", () => {
+  it("averages the population standard deviation across channels", () => {
+    // [-1, 1] has std 1; [-2, 2] has std 2; mean is 1.5
+    expect(
+      computeAvgStdDev([
+        [-1, 1],
+        [-2, 2],
+      ]),
+    ).toBeCloseTo(1.5);
+  });
+  it("ignores NaN samples and empty channels", () => {
+    expect(computeAvgStdDev([[-1, NaN, 1], [NaN]])).toBeCloseTo(0.5);
+    expect(computeAvgStdDev([])).toBe(0);
+  });
+});
+
+describe("channelOffset", () => {
+  it("stacks the first channel highest and the last at zero", () => {
+    expect(channelOffset(3, 0, 2, 1.5)).toBe(6);
+    expect(channelOffset(3, 1, 2, 1.5)).toBe(3);
+    expect(channelOffset(3, 2, 2, 1.5)).toBe(0);
+  });
+});
+
+describe("computeYRange", () => {
+  const data = [
+    [-1, 1],
+    [-1, 1],
+  ];
+  const ranges = computeChannelRanges(data);
+  const avgStdDev = computeAvgStdDev(data); // 1
+
+  it("covers the raw data when there is no separation", () => {
+    const { yMin, yMax } = computeYRange(ranges, 0, avgStdDev, 0);
+    expect(yMin).toBe(-1);
+    expect(yMax).toBe(1);
+  });
+
+  it("applies the separation offset exactly once", () => {
+    // Channel 0 is shifted up by (2 - 1 - 0) * 2 * 1 = 2, so it spans
+    // [1, 3]; channel 1 stays at [-1, 1]. The union is [-1, 3]. The old
+    // worker added the offset both when storing per-channel extremes and
+    // again when computing the axis, giving [-1, 5].
+    const { yMin, yMax } = computeYRange(ranges, 2, avgStdDev, 0);
+    expect(yMin).toBe(-1);
+    expect(yMax).toBe(3);
+  });
+
+  it("matches the offset used to draw each channel", () => {
+    const separation = 3;
+    const { yMax } = computeYRange(ranges, separation, avgStdDev, 0);
+    const topOfFirstChannel =
+      ranges.maxs[0] + channelOffset(2, 0, separation, avgStdDev);
+    expect(yMax).toBe(topOfFirstChannel);
+  });
+
+  it("pads the range by the given fraction", () => {
+    const { yMin, yMax } = computeYRange(ranges, 0, avgStdDev, 0.05);
+    expect(yMin).toBeCloseTo(-1.1);
+    expect(yMax).toBeCloseTo(1.1);
+  });
+
+  it("reflects a changed separation without recomputing the ranges", () => {
+    const a = computeYRange(ranges, 1, avgStdDev, 0).yMax;
+    const b = computeYRange(ranges, 4, avgStdDev, 0).yMax;
+    expect(b - a).toBe(3);
+  });
+});

--- a/src/pages/NwbPage/plugins/simple-timeseries/timeseriesPlotMath.ts
+++ b/src/pages/NwbPage/plugins/simple-timeseries/timeseriesPlotMath.ts
@@ -1,0 +1,80 @@
+// Pure helpers for the canvas timeseries plot worker. Kept separate from the
+// worker so they can be unit tested.
+
+export const computeMin = (arr: ArrayLike<number>): number => {
+  let min = Infinity;
+  for (let i = 0; i < arr.length; i++) {
+    if (isNaN(arr[i])) continue;
+    min = Math.min(min, arr[i]);
+  }
+  return min;
+};
+
+export const computeMax = (arr: ArrayLike<number>): number => {
+  let max = -Infinity;
+  for (let i = 0; i < arr.length; i++) {
+    if (isNaN(arr[i])) continue;
+    max = Math.max(max, arr[i]);
+  }
+  return max;
+};
+
+// Mean over channels of each channel's population standard deviation,
+// ignoring NaN samples. Used as the unit for channel separation.
+export const computeAvgStdDev = (data: number[][]): number => {
+  if (data.length === 0) return 0;
+  const total = data.reduce((sum, channel) => {
+    const channelWithoutNaN = channel.filter((val) => !isNaN(val));
+    if (channelWithoutNaN.length === 0) return sum;
+    const mean =
+      channelWithoutNaN.reduce((sum, val) => sum + val, 0) /
+      channelWithoutNaN.length;
+    const variance =
+      channelWithoutNaN.reduce((sum, val) => sum + Math.pow(val - mean, 2), 0) /
+      channelWithoutNaN.length;
+    return sum + Math.sqrt(variance);
+  }, 0);
+  return total / data.length;
+};
+
+// Raw (un-offset) extremes of every channel.
+export const computeChannelRanges = (
+  data: number[][],
+): { mins: number[]; maxs: number[] } => {
+  const mins: number[] = [];
+  const maxs: number[] = [];
+  for (let i = 0; i < data.length; i++) {
+    mins.push(computeMin(data[i]));
+    maxs.push(computeMax(data[i]));
+  }
+  return { mins, maxs };
+};
+
+// Vertical offset added to channel i so that channels are stacked with the
+// first channel on top.
+export const channelOffset = (
+  numChannels: number,
+  channelIndex: number,
+  channelSeparation: number,
+  avgStdDev: number,
+): number => (numChannels - 1 - channelIndex) * channelSeparation * avgStdDev;
+
+// The y-axis range that fits every channel after its offset is applied,
+// with a little padding on each side.
+export const computeYRange = (
+  ranges: { mins: number[]; maxs: number[] },
+  channelSeparation: number,
+  avgStdDev: number,
+  paddingFraction = 0.05,
+): { yMin: number; yMax: number } => {
+  const n = ranges.mins.length;
+  let yMin = Infinity;
+  let yMax = -Infinity;
+  for (let i = 0; i < n; i++) {
+    const offset = channelOffset(n, i, channelSeparation, avgStdDev);
+    yMin = Math.min(yMin, ranges.mins[i] + offset);
+    yMax = Math.max(yMax, ranges.maxs[i] + offset);
+  }
+  const padding = (yMax - yMin) * paddingFraction;
+  return { yMin: yMin - padding, yMax: yMax + padding };
+};

--- a/src/pages/NwbPage/plugins/simple-timeseries/timeseriesPlotTSV2Worker.ts
+++ b/src/pages/NwbPage/plugins/simple-timeseries/timeseriesPlotTSV2Worker.ts
@@ -1,41 +1,23 @@
 import { PlotOpts, PlotData } from "./types";
+import {
+  channelOffset,
+  computeAvgStdDev,
+  computeChannelRanges,
+  computeYRange,
+} from "./timeseriesPlotMath";
 
 let canvas: OffscreenCanvas | undefined = undefined;
 let plotOpts: PlotOpts | undefined = undefined;
 let plotData: PlotData | undefined = undefined;
 
+// Derived from plotData alone. The channel separation offset depends on
+// plotOpts and is applied at draw time, so changing the separation does not
+// require recomputing these.
 let avgStdDev = 0;
-let yMins: number[] = [];
-let yMaxs: number[] = [];
+let channelRanges: { mins: number[]; maxs: number[] } = { mins: [], maxs: [] };
 const doPlotDataCalculations = () => {
-  avgStdDev =
-    plotData!.data.length === 0
-      ? 0
-      : plotData!.data.reduce((sum, channel) => {
-          const channelWithoutNaN = channel.filter((val) => !isNaN(val));
-          if (channelWithoutNaN.length === 0) return sum;
-          const mean =
-            channelWithoutNaN.reduce((sum, val) => sum + val, 0) /
-            channelWithoutNaN.length;
-          const squaredDiffs = channelWithoutNaN.map((val) =>
-            Math.pow(val - mean, 2),
-          );
-          const variance =
-            squaredDiffs.reduce((sum, val) => sum + val, 0) /
-            channelWithoutNaN.length;
-          return sum + Math.sqrt(variance);
-        }, 0) / plotData!.data.length;
-
-  yMins = [];
-  yMaxs = [];
-  for (let i = 0; i < plotData!.data.length; i++) {
-    const offset =
-      (plotData!.data.length - 1 - i) * plotOpts!.channelSeparation * avgStdDev;
-    const channelMin = compute_min(plotData!.data[i]) + offset;
-    const channelMax = compute_max(plotData!.data[i]) + offset;
-    yMins[i] = channelMin;
-    yMaxs[i] = channelMax;
-  }
+  avgStdDev = computeAvgStdDev(plotData!.data);
+  channelRanges = computeChannelRanges(plotData!.data);
 };
 
 const draw = async () => {
@@ -59,29 +41,11 @@ const draw = async () => {
     return;
   }
 
-  let yMin = compute_min(
-    yMins.map(
-      (val, i) =>
-        val +
-        (plotData!.data.length - 1 - i) *
-          plotOpts!.channelSeparation *
-          avgStdDev,
-    ),
+  const { yMin, yMax } = computeYRange(
+    channelRanges,
+    plotOpts.channelSeparation,
+    avgStdDev,
   );
-  let yMax = compute_max(
-    yMaxs.map(
-      (val, i) =>
-        val +
-        (plotData!.data.length - 1 - i) *
-          plotOpts!.channelSeparation *
-          avgStdDev,
-    ),
-  );
-
-  // Add padding to value range
-  const yPadding = (yMax - yMin) * 0.05;
-  yMin -= yPadding;
-  yMax += yPadding;
 
   // Post yMin and yMax back to main thread
   postMessage({
@@ -139,8 +103,12 @@ const draw = async () => {
   let timer = Date.now();
   for (let i = 0; i < plotData.data.length; i++) {
     const channel = plotData.data[i];
-    const offset =
-      (plotData.data.length - 1 - i) * plotOpts.channelSeparation * avgStdDev;
+    const offset = channelOffset(
+      plotData.data.length,
+      i,
+      plotOpts.channelSeparation,
+      avgStdDev,
+    );
 
     ctx.strokeStyle = colors[i % colors.length];
     ctx.beginPath();
@@ -204,21 +172,3 @@ onmessage = (e: MessageEvent) => {
     throttledDraw();
   }
 };
-
-function compute_min(arr: number[]) {
-  let min = Infinity;
-  for (let i = 0; i < arr.length; i++) {
-    if (isNaN(arr[i])) continue;
-    min = Math.min(min, arr[i]);
-  }
-  return min;
-}
-
-function compute_max(arr: number[]) {
-  let max = -Infinity;
-  for (let i = 0; i < arr.length; i++) {
-    if (isNaN(arr[i])) continue;
-    max = Math.max(max, arr[i]);
-  }
-  return max;
-}


### PR DESCRIPTION
Fixes #462.

The canvas timeseries worker added the channel separation offset to each channel's stored min and max and then again when computing the y-axis range, while the traces were drawn with the offset once. With separation enabled the axis was about twice as tall as needed and the traces sat in the lower half. Because the stored extremes included the offset and were only recomputed on new data, changing the separation alone also left the axis out of step with the traces.

The math moves into `timeseriesPlotMath.ts`. When data arrives the worker computes the average standard deviation and the raw extremes; at draw time `computeYRange` applies `channelOffset` once per channel, and the trace loop uses the same helper, so the two cannot drift apart. The worker file loses its duplicate min and max functions.

Tests in `timeseriesPlotMath.test.ts` cover NaN handling in the extremes, the average standard deviation, the stacking order of the offset, that the range equals the raw span plus a single offset (the old code gave `[-1, 5]` where `[-1, 3]` is right), that the top of the range matches the drawn top of the first channel, padding, and that a separation change is reflected without recomputing the extremes. `vite build` still emits the worker chunk with the new import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c