### PR TITLE
Fix sorting of string columns in the dynamic table

### DIFF
--- a/src/pages/NwbPage/plugins/dynamic-table/DynamicTable/DynamicTable.tsx
+++ b/src/pages/NwbPage/plugins/dynamic-table/DynamicTable/DynamicTable.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { ColumnSortState, RowItem, sortRowItems } from "./sortRowItems";
 import {
   FunctionComponent,
   useCallback,
@@ -42,17 +43,6 @@ const dataReducer = (state: DataState, action: DataAction) => {
       [action.key]: action.data,
     };
   } else return state;
-};
-
-type ColumnSortState = {
-  primary?: {
-    column: string;
-    ascending: boolean;
-  };
-  secondary?: {
-    column: string;
-    ascending: boolean;
-  };
 };
 
 type ColumnSortAction = {
@@ -120,11 +110,6 @@ const columnDescriptionReducer = (
       [action.column]: action.description,
     };
   } else return state;
-};
-
-type RowItem = {
-  id: string | number;
-  columnValues: any[];
 };
 
 const DynamicTable: FunctionComponent<Props> = ({
@@ -322,35 +307,7 @@ const DynamicTable: FunctionComponent<Props> = ({
 
   const sortedRowItems = useMemo(() => {
     if (!validColumnNames) return rowItems;
-    const primary = columnSortState.primary;
-    const secondary = columnSortState.secondary;
-    if (!primary) return rowItems;
-    const primaryColIndex = validColumnNames.indexOf(primary.column);
-    if (primaryColIndex < 0) return rowItems;
-    const secondaryColIndex = secondary
-      ? validColumnNames.indexOf(secondary.column)
-      : -1;
-    const ret = [...rowItems];
-    ret.sort((a, b) => {
-      const valA = a.columnValues[primaryColIndex];
-      const valB = b.columnValues[primaryColIndex];
-      if (valA === undefined) return 1;
-      if (valB === undefined) return -1;
-      if (isNaN(valA)) return 1;
-      if (isNaN(valB)) return -1;
-      if (valA < valB) return primary.ascending ? -1 : 1;
-      if (valA > valB) return primary.ascending ? 1 : -1;
-      if (secondaryColIndex >= 0 && secondary) {
-        const valA2 = a.columnValues[secondaryColIndex];
-        const valB2 = b.columnValues[secondaryColIndex];
-        if (valA2 === undefined) return 1;
-        if (valB2 === undefined) return -1;
-        if (valA2 < valB2) return secondary.ascending ? -1 : 1;
-        if (valA2 > valB2) return secondary.ascending ? 1 : -1;
-      }
-      return 0;
-    });
-    return ret;
+    return sortRowItems(rowItems, validColumnNames, columnSortState);
   }, [validColumnNames, rowItems, columnSortState]);
 
   const [columnDescriptions, columnDescriptionDispatch] = useReducer(

--- a/src/pages/NwbPage/plugins/dynamic-table/DynamicTable/sortRowItems.test.ts
+++ b/src/pages/NwbPage/plugins/dynamic-table/DynamicTable/sortRowItems.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { RowItem, sortRowItems } from "./sortRowItems";
+
+const columns = ["id", "location", "quality", "depth"];
+const rows: RowItem[] = [
+  { id: 0, columnValues: [0, "right", "good", 120.5] },
+  { id: 1, columnValues: [1, "left", "mua", 80] },
+  { id: 2, columnValues: [2, "center", "good", NaN] },
+  { id: 3, columnValues: [3, "left", "noise", 200] },
+  { id: 4, columnValues: [4, undefined, "good", 10] },
+];
+const ids = (r: RowItem[]) => r.map((x) => x.id);
+
+describe("sortRowItems", () => {
+  it("returns the rows unchanged with no primary sort", () => {
+    expect(sortRowItems(rows, columns, {})).toBe(rows);
+  });
+
+  it("sorts string columns lexicographically", () => {
+    const asc = sortRowItems(rows, columns, {
+      primary: { column: "location", ascending: true },
+    });
+    expect(ids(asc)).toEqual([2, 1, 3, 0, 4]);
+    const desc = sortRowItems(rows, columns, {
+      primary: { column: "location", ascending: false },
+    });
+    expect(ids(desc)).toEqual([0, 1, 3, 2, 4]);
+  });
+
+  it("sorts numeric columns numerically with NaN last", () => {
+    const asc = sortRowItems(rows, columns, {
+      primary: { column: "depth", ascending: true },
+    });
+    expect(ids(asc)).toEqual([4, 1, 0, 3, 2]);
+    const desc = sortRowItems(rows, columns, {
+      primary: { column: "depth", ascending: false },
+    });
+    expect(ids(desc)).toEqual([3, 0, 1, 4, 2]);
+  });
+
+  it("does not treat strings as NaN", () => {
+    // isNaN("left") is true, which is how the old comparator broke string
+    // sorts: every pair compared as "missing" and the order was arbitrary.
+    const sorted = sortRowItems(rows, columns, {
+      primary: { column: "quality", ascending: true },
+    });
+    expect(sorted.map((r) => r.columnValues[2])).toEqual([
+      "good",
+      "good",
+      "good",
+      "mua",
+      "noise",
+    ]);
+  });
+
+  it("applies the secondary sort within ties", () => {
+    const sorted = sortRowItems(rows, columns, {
+      primary: { column: "quality", ascending: true },
+      secondary: { column: "depth", ascending: false },
+    });
+    expect(ids(sorted)).toEqual([0, 4, 2, 1, 3]);
+  });
+
+  it("puts missing values last in both directions", () => {
+    const asc = sortRowItems(rows, columns, {
+      primary: { column: "location", ascending: true },
+    });
+    expect(asc[asc.length - 1].id).toBe(4);
+    const desc = sortRowItems(rows, columns, {
+      primary: { column: "location", ascending: false },
+    });
+    expect(desc[desc.length - 1].id).toBe(4);
+  });
+
+  it("does not mutate the input", () => {
+    const before = ids(rows);
+    sortRowItems(rows, columns, {
+      primary: { column: "depth", ascending: true },
+    });
+    expect(ids(rows)).toEqual(before);
+  });
+
+  it("ignores an unknown sort column", () => {
+    expect(
+      sortRowItems(rows, columns, {
+        primary: { column: "nope", ascending: true },
+      }),
+    ).toBe(rows);
+  });
+});

--- a/src/pages/NwbPage/plugins/dynamic-table/DynamicTable/sortRowItems.ts
+++ b/src/pages/NwbPage/plugins/dynamic-table/DynamicTable/sortRowItems.ts
@@ -1,0 +1,69 @@
+export type RowItem = {
+  id: string | number;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  columnValues: any[];
+};
+
+export type ColumnSort = {
+  column: string;
+  ascending: boolean;
+};
+
+export type ColumnSortState = {
+  primary?: ColumnSort;
+  secondary?: ColumnSort;
+};
+
+// Missing values (undefined) and NaN numbers sort to the end regardless of
+// direction. Everything else is compared with < and >, which orders numbers
+// numerically and strings lexicographically.
+const isMissing = (v: unknown): boolean =>
+  v === undefined || (typeof v === "number" && isNaN(v));
+
+const compareValues = (a: unknown, b: unknown, ascending: boolean): number => {
+  const aMissing = isMissing(a);
+  const bMissing = isMissing(b);
+  if (aMissing && bMissing) return 0;
+  if (aMissing) return 1;
+  if (bMissing) return -1;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const x = a as any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const y = b as any;
+  if (x < y) return ascending ? -1 : 1;
+  if (x > y) return ascending ? 1 : -1;
+  return 0;
+};
+
+export const sortRowItems = (
+  rowItems: RowItem[],
+  columnNames: string[],
+  sortState: ColumnSortState,
+): RowItem[] => {
+  const primary = sortState.primary;
+  if (!primary) return rowItems;
+  const primaryColIndex = columnNames.indexOf(primary.column);
+  if (primaryColIndex < 0) return rowItems;
+  const secondary = sortState.secondary;
+  const secondaryColIndex = secondary
+    ? columnNames.indexOf(secondary.column)
+    : -1;
+  const ret = [...rowItems];
+  ret.sort((a, b) => {
+    const c = compareValues(
+      a.columnValues[primaryColIndex],
+      b.columnValues[primaryColIndex],
+      primary.ascending,
+    );
+    if (c !== 0) return c;
+    if (secondaryColIndex >= 0 && secondary) {
+      return compareValues(
+        a.columnValues[secondaryColIndex],
+        b.columnValues[secondaryColIndex],
+        secondary.ascending,
+      );
+    }
+    return 0;
+  });
+  return ret;
+};


### PR DESCRIPTION
Fixes #464.

The table's sort comparator called `isNaN(value)` to push NaN entries to the end. Since `isNaN` is true for any non-numeric string, a string column compared every pair as missing and returned 1, so clicking a header such as `location` or `quality` shuffled the rows rather than sorting them.

The comparator now lives in `sortRowItems.ts`, along with the `RowItem` and `ColumnSortState` types it needs, and treats a value as missing only when it is `undefined` or a NaN number. Missing values go last in both directions, which the old code did for the primary column and I kept. `DynamicTable.tsx` shrinks by the inline comparator.

Tests in `sortRowItems.test.ts` cover string sorting ascending and descending, numeric sorting with NaN last, that strings are not treated as NaN, the secondary sort within ties, missing values last in both directions, that the input is not mutated, and unknown sort columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c