### PR TITLE
Stop dropping samples at chunk boundaries and series ends

### DIFF
--- a/src/pages/NwbPage/plugins/PSTH/PSTHItemView/DirectSpikeTrainsClient.test.ts
+++ b/src/pages/NwbPage/plugins/PSTH/PSTHItemView/DirectSpikeTrainsClient.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Units table with two units whose spike times are stored ragged, the way
+// pynwb writes spike_times and spike_times_index.
+const unitSpikes: number[][] = [
+  [0.1, 0.5, 0.99, 1.0, 1.5, 2.9],
+  [0.2, 1.2, 1.95, 2.0, 2.05],
+];
+const spikeTimes = unitSpikes.flat();
+const spikeTimesIndex = unitSpikes.reduce<number[]>((acc, u) => {
+  acc.push((acc[acc.length - 1] ?? 0) + u.length);
+  return acc;
+}, []);
+const requests: [number, number][] = [];
+
+vi.mock("@hdf5Interface", () => ({
+  getHdf5Group: async (_url: string, path: string) => ({
+    path,
+    subgroups: [],
+    datasets: ["id", "spike_times", "spike_times_index"].map((name) => ({
+      name,
+      path: `${path}/${name}`,
+    })),
+    attrs: {},
+  }),
+  getHdf5DatasetData: async (
+    _url: string,
+    path: string,
+    o: { slice?: [number, number][] },
+  ) => {
+    if (path.endsWith("/id")) return Int32Array.from([0, 1]);
+    if (path.endsWith("/spike_times_index"))
+      return Int32Array.from(spikeTimesIndex);
+    if (path.endsWith("/spike_times")) {
+      const [i1, i2] = o.slice?.[0] ?? [0, spikeTimes.length];
+      requests.push([i1, i2]);
+      return Float64Array.from(spikeTimes.slice(i1, i2));
+    }
+    return undefined;
+  },
+}));
+
+const { ChunkedDirectSpikeTrainsClient } =
+  await import("./DirectSpikeTrainsClient");
+
+const inRange = (unit: number, t1: number, t2: number) =>
+  unitSpikes[unit].filter((t) => t >= t1 && t < t2);
+
+describe("ChunkedDirectSpikeTrainsClient", () => {
+  beforeEach(() => {
+    requests.length = 0;
+  });
+
+  it("returns every spike of a unit including the last one", async () => {
+    const client = await ChunkedDirectSpikeTrainsClient.create(
+      "u",
+      "/units",
+      1,
+    );
+    const spikes = await client.getUnitSpikeTrainForTimeRange(0, 0, 3);
+    expect(spikes).toEqual(unitSpikes[0]);
+  });
+
+  it("keeps spikes that are nearest to but below a chunk boundary", async () => {
+    const client = await ChunkedDirectSpikeTrainsClient.create(
+      "u",
+      "/units",
+      1,
+    );
+    // Unit 0 has spikes at 1.5 and 2.9 that a loader using the nearest index
+    // as an exclusive bound never returns.
+    expect(await client.getUnitSpikeTrainForTimeRange(0, 1, 2)).toEqual(
+      inRange(0, 1, 2),
+    );
+    expect(await client.getUnitSpikeTrainForTimeRange(0, 2, 3)).toEqual(
+      inRange(0, 2, 3),
+    );
+    expect(await client.getUnitSpikeTrainForTimeRange(1, 1, 2)).toEqual(
+      inRange(1, 1, 2),
+    );
+  });
+
+  it("does not duplicate spikes on chunk boundaries", async () => {
+    const client = await ChunkedDirectSpikeTrainsClient.create(
+      "u",
+      "/units",
+      1,
+    );
+    const spikes = await client.getUnitSpikeTrainForTimeRange(1, 0.5, 2.5);
+    expect(spikes).toEqual(inRange(1, 0.5, 2.5));
+    expect(new Set(spikes).size).toBe(spikes.length);
+  });
+
+  it("respects the requested range within a chunk", async () => {
+    const client = await ChunkedDirectSpikeTrainsClient.create(
+      "u",
+      "/units",
+      1,
+    );
+    expect(await client.getUnitSpikeTrainForTimeRange(0, 0.3, 0.995)).toEqual([
+      0.5, 0.99,
+    ]);
+    expect(await client.getUnitSpikeTrainForTimeRange(0, 0.99, 1.0)).toEqual([
+      0.99,
+    ]);
+  });
+
+  it("returns nothing for an empty range", async () => {
+    const client = await ChunkedDirectSpikeTrainsClient.create(
+      "u",
+      "/units",
+      1,
+    );
+    expect(await client.getUnitSpikeTrainForTimeRange(0, 0.6, 0.9)).toEqual([]);
+  });
+
+  it("only reads the unit's own slice of spike_times", async () => {
+    const client = await ChunkedDirectSpikeTrainsClient.create(
+      "u",
+      "/units",
+      1,
+    );
+    requests.length = 0;
+    await client.getUnitSpikeTrainForTimeRange(1, 0, 3);
+    const [lo, hi] = [spikeTimesIndex[0], spikeTimesIndex[1]];
+    for (const [i1, i2] of requests) {
+      expect(i1).toBeGreaterThanOrEqual(lo);
+      expect(i2).toBeLessThanOrEqual(hi);
+    }
+  });
+});

--- a/src/pages/NwbPage/plugins/PSTH/PSTHItemView/DirectSpikeTrainsClient.ts
+++ b/src/pages/NwbPage/plugins/PSTH/PSTHItemView/DirectSpikeTrainsClient.ts
@@ -139,11 +139,17 @@ export class DirectSpikeTrainsClient {
       this._createTimestampFinder(ii);
     }
     const finder = this.#timestampFinders[ii];
+    // getDataIndexForTime returns the nearest spike, which may lie on either
+    // side of the requested time. Load through the spike after the one
+    // nearest t2 and keep exactly the spikes in [t1, t2).
     const index1 = await finder.getDataIndexForTime(t1);
     const index2 = await finder.getDataIndexForTime(t2);
     if (index1 > index2) throw Error("Unexpected: index1 > index2");
-    const tt = await finder.getDataForIndices(index1, index2);
-    return tt;
+    const tt = await finder.getDataForIndices(
+      index1,
+      Math.min(index2 + 1, finder.length),
+    );
+    return tt.filter((t) => t >= t1 && t < t2);
   }
 }
 
@@ -231,6 +237,9 @@ class TimestampFinder {
     private timestampsModel: TimestampsModel,
     // private estimatedSamplingFrequency: number,
   ) {}
+  get length() {
+    return this.timestampsModel.length;
+  }
   async getDataIndexForTime(time: number): Promise<number> {
     let iLower = 0;
     let iUpper = this.timestampsModel.length - 1;

--- a/src/pages/NwbPage/plugins/simple-timeseries/TimeseriesClient.test.ts
+++ b/src/pages/NwbPage/plugins/simple-timeseries/TimeseriesClient.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// An in-memory stand-in for the HDF5 interface: each dataset is a flat
+// row-major array with a shape and attributes, and slices return the
+// flattened rectangle, which is what the real interface returns.
+type FakeDataset = {
+  shape: number[];
+  attrs: { [key: string]: unknown };
+  values: number[] | number;
+};
+const datasets: { [path: string]: FakeDataset } = {};
+const dataRequests: { path: string; slice?: [number, number][] }[] = [];
+
+const sliceDataset = (ds: FakeDataset, slice?: [number, number][]) => {
+  if (typeof ds.values === "number") return ds.values;
+  if (!slice || slice.length === 0) return Float64Array.from(ds.values);
+  const [i1, i2] = slice[0];
+  if (ds.shape.length === 1) {
+    return Float64Array.from(ds.values.slice(i1, i2));
+  }
+  const nCols = ds.shape[1];
+  const [j1, j2] = slice.length > 1 ? slice[1] : [0, nCols];
+  const out: number[] = [];
+  for (let i = i1; i < i2; i++) {
+    for (let j = j1; j < j2; j++) out.push(ds.values[i * nCols + j]);
+  }
+  return Float64Array.from(out);
+};
+
+vi.mock("@hdf5Interface", () => ({
+  getHdf5Dataset: async (_url: string, path: string) => {
+    const ds = datasets[path];
+    if (!ds) return undefined;
+    return {
+      name: path.split("/").pop(),
+      path,
+      shape: ds.shape,
+      dtype: "<f8",
+      attrs: ds.attrs,
+    };
+  },
+  getHdf5DatasetData: async (
+    _url: string,
+    path: string,
+    o: { slice?: [number, number][] },
+  ) => {
+    const ds = datasets[path];
+    if (!ds) return undefined;
+    dataRequests.push({ path, slice: o.slice });
+    return sliceDataset(ds, o.slice);
+  },
+  getHdf5Group: async (_url: string, path: string) => ({
+    path,
+    subgroups: [],
+    datasets: Object.keys(datasets)
+      .filter((p) => p.startsWith(path + "/"))
+      .map((p) => ({ name: p.slice(path.length + 1), path: p })),
+    attrs: {},
+  }),
+  useHdf5Group: () => undefined,
+}));
+
+const { ChunkedTimeseriesClient } = await import("./TimeseriesClient");
+
+const group = (path: string) =>
+  ({
+    path,
+    subgroups: [],
+    datasets: Object.keys(datasets)
+      .filter((p) => p.startsWith(path + "/"))
+      .map((p) => ({
+        name: p.slice(path.length + 1),
+        path: p,
+        shape: datasets[p].shape,
+        dtype: "<f8",
+        attrs: datasets[p].attrs,
+      })),
+    attrs: {},
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any;
+
+const reset = () => {
+  for (const k of Object.keys(datasets)) delete datasets[k];
+  dataRequests.length = 0;
+};
+
+// A regular series at 10 Hz starting at t = 0 with 25 samples, so the
+// timestamps are 0, 0.1, ..., 2.4 and the series ends at 2.5. Two channels;
+// channel c sample i holds 100 * c + i.
+const setupRegular = (numChannels = 2, numSamples = 25) => {
+  reset();
+  const values: number[] = [];
+  for (let i = 0; i < numSamples; i++) {
+    for (let c = 0; c < numChannels; c++) values.push(100 * c + i);
+  }
+  datasets["/acq/ts/data"] = {
+    shape: [numSamples, numChannels],
+    attrs: { conversion: 1, offset: 0 },
+    values,
+  };
+  datasets["/acq/ts/starting_time"] = {
+    shape: [],
+    attrs: { rate: 10 },
+    values: 0,
+  };
+};
+
+// An irregular series with hand-picked timestamps around chunk boundaries.
+const irregularTimes = [0.05, 0.3, 0.98, 1.0, 1.01, 1.99, 2.5];
+const setupIrregular = () => {
+  reset();
+  datasets["/acq/irr/data"] = {
+    shape: [irregularTimes.length, 1],
+    attrs: {},
+    values: irregularTimes.map((_, i) => i),
+  };
+  datasets["/acq/irr/timestamps"] = {
+    shape: [irregularTimes.length],
+    attrs: {},
+    values: irregularTimes,
+  };
+};
+
+const expectedRegularTimes = (t1: number, t2: number) => {
+  const out: number[] = [];
+  for (let i = 0; i < 25; i++) {
+    const t = i / 10;
+    if (t >= t1 && t < t2) out.push(t);
+  }
+  return out;
+};
+
+describe("ChunkedTimeseriesClient with a regular series", () => {
+  beforeEach(() => setupRegular());
+
+  it("returns every sample of the series including the last one", async () => {
+    const client = await ChunkedTimeseriesClient.create("u", group("/acq/ts"), {
+      chunkSizeSec: 1,
+    });
+    const { timestamps, data } = await client.getDataForTimeRange(0, 2.5, 0, 2);
+    expect(timestamps.map((t) => +t.toFixed(6))).toEqual(
+      expectedRegularTimes(0, 2.5),
+    );
+    expect(timestamps).toHaveLength(25);
+    expect(data[0]).toEqual(Array.from({ length: 25 }, (_, i) => i));
+    expect(data[1]).toEqual(Array.from({ length: 25 }, (_, i) => 100 + i));
+  });
+
+  it("keeps the sample just below a chunk boundary", async () => {
+    const client = await ChunkedTimeseriesClient.create("u", group("/acq/ts"), {
+      chunkSizeSec: 1,
+    });
+    // 0.94 is nearer to sample 9 (t = 0.9) than to sample 10, so a loader
+    // that treats the nearest index as an exclusive bound drops t = 0.9.
+    const { timestamps } = await client.getDataForTimeRange(0, 0.94, 0, 2);
+    expect(timestamps.map((t) => +t.toFixed(6))).toEqual(
+      expectedRegularTimes(0, 0.94),
+    );
+  });
+
+  it("does not duplicate samples across chunk boundaries", async () => {
+    const client = await ChunkedTimeseriesClient.create("u", group("/acq/ts"), {
+      chunkSizeSec: 1,
+    });
+    const { timestamps, data } = await client.getDataForTimeRange(
+      0.5,
+      2.05,
+      0,
+      2,
+    );
+    const rounded = timestamps.map((t) => +t.toFixed(6));
+    expect(rounded).toEqual(expectedRegularTimes(0.5, 2.05));
+    expect(new Set(rounded).size).toBe(rounded.length);
+    expect(data[0]).toEqual(rounded.map((t) => Math.round(t * 10)));
+  });
+
+  it("returns the same samples whether a range is loaded at once or in pieces", async () => {
+    const whole = await ChunkedTimeseriesClient.create("u", group("/acq/ts"), {
+      chunkSizeSec: 1,
+    });
+    const all = await whole.getDataForTimeRange(0, 2.5, 0, 2);
+    const pieces = await ChunkedTimeseriesClient.create("u", group("/acq/ts"), {
+      chunkSizeSec: 1,
+    });
+    const a = await pieces.getDataForTimeRange(0, 0.95, 0, 2);
+    const b = await pieces.getDataForTimeRange(0.95, 1.7, 0, 2);
+    const c = await pieces.getDataForTimeRange(1.7, 2.5, 0, 2);
+    expect([...a.timestamps, ...b.timestamps, ...c.timestamps]).toEqual(
+      all.timestamps,
+    );
+    expect([...a.data[1], ...b.data[1], ...c.data[1]]).toEqual(all.data[1]);
+  });
+
+  it("does not load a chunk that starts exactly at the end of the range", async () => {
+    const client = await ChunkedTimeseriesClient.create("u", group("/acq/ts"), {
+      chunkSizeSec: 1,
+    });
+    dataRequests.length = 0;
+    await client.getDataForTimeRange(0, 1, 0, 2);
+    const dataSlices = dataRequests
+      .filter((r) => r.path === "/acq/ts/data")
+      .map((r) => r.slice![0]);
+    expect(dataSlices).toHaveLength(1);
+  });
+
+  it("does not load an extra channel chunk when the channel range ends on a boundary", async () => {
+    setupRegular(8);
+    const client = await ChunkedTimeseriesClient.create("u", group("/acq/ts"), {
+      chunkSizeSec: 1,
+      chunkSizeNumChannels: 8,
+    });
+    dataRequests.length = 0;
+    const { data } = await client.getDataForTimeRange(0, 1, 0, 8);
+    expect(data).toHaveLength(8);
+    const channelSlices = dataRequests
+      .filter((r) => r.path === "/acq/ts/data")
+      .map((r) => r.slice![1]);
+    expect(channelSlices).toEqual([[0, 8]]);
+  });
+});
+
+describe("ChunkedTimeseriesClient with an irregular series", () => {
+  beforeEach(() => setupIrregular());
+
+  it("returns every timestamp including the last one", async () => {
+    const client = await ChunkedTimeseriesClient.create(
+      "u",
+      group("/acq/irr"),
+      { chunkSizeSec: 1 },
+    );
+    const { timestamps, data } = await client.getDataForTimeRange(0, 3, 0, 1);
+    expect(timestamps).toEqual(irregularTimes);
+    expect(data[0]).toEqual([0, 1, 2, 3, 4, 5, 6]);
+  });
+
+  it("keeps a sample that is nearest to but below the end of the range", async () => {
+    const client = await ChunkedTimeseriesClient.create(
+      "u",
+      group("/acq/irr"),
+      { chunkSizeSec: 1 },
+    );
+    const { timestamps } = await client.getDataForTimeRange(0.5, 1.995, 0, 1);
+    expect(timestamps).toEqual([0.98, 1.0, 1.01, 1.99]);
+  });
+});

--- a/src/pages/NwbPage/plugins/simple-timeseries/TimeseriesClient.ts
+++ b/src/pages/NwbPage/plugins/simple-timeseries/TimeseriesClient.ts
@@ -140,6 +140,10 @@ class TimeseriesClient {
     channelEnd: number,
   ) {
     if (tStart > tEnd) throw new Error("tStart must be <= tEnd");
+    // getDataIndexForTime returns the index of the sample nearest to the
+    // requested time, which may lie on either side of it. Load one sample
+    // past the nearest-to-tEnd index (it may itself be before tEnd) and then
+    // keep exactly the samples whose timestamps fall in [tStart, tEnd).
     const iStart = await this.timestampsClient.getDataIndexForTime(tStart);
     const iEnd = await this.timestampsClient.getDataIndexForTime(tEnd);
     if (iStart > iEnd) {
@@ -157,9 +161,34 @@ class TimeseriesClient {
         data: [],
       };
     }
-    return this.getDataForIndices(iStart, iEnd, channelStart, channelEnd);
+    const iEndInclusive = Math.min(iEnd + 1, this.numSamples);
+    const loaded = await this.getDataForIndices(
+      iStart,
+      iEndInclusive,
+      channelStart,
+      channelEnd,
+    );
+    return trimToTimeRange(loaded, tStart, tEnd);
   }
 }
+
+// Keep only the samples whose timestamp lies in [tStart, tEnd).
+export const trimToTimeRange = (
+  loaded: { timestamps: number[]; data: number[][] },
+  tStart: number,
+  tEnd: number,
+): { timestamps: number[]; data: number[][] } => {
+  const keep: number[] = [];
+  for (let k = 0; k < loaded.timestamps.length; k++) {
+    const t = loaded.timestamps[k];
+    if (t >= tStart && t < tEnd) keep.push(k);
+  }
+  if (keep.length === loaded.timestamps.length) return loaded;
+  return {
+    timestamps: keep.map((k) => loaded.timestamps[k]),
+    data: loaded.data.map((channel) => keep.map((k) => channel[k])),
+  };
+};
 
 interface TimeseriesChunk {
   startTime: number;
@@ -216,8 +245,28 @@ export class ChunkedTimeseriesClient {
     return Math.floor(time / this.chunkSizeSec);
   }
 
+  // Index of the last chunk touched by a half-open range ending at tEnd. A
+  // range that ends exactly on a chunk boundary does not touch the chunk
+  // that starts there.
+  private getLastChunkTimeIndex(tStart: number, tEnd: number): number {
+    return Math.max(
+      this.getChunkTimeIndex(tStart),
+      Math.ceil(tEnd / this.chunkSizeSec) - 1,
+    );
+  }
+
   private getChunkChannelIndex(channel: number): number {
     return Math.floor(channel / this.chunkSizeNumChannels);
+  }
+
+  private getLastChunkChannelIndex(
+    channelStart: number,
+    channelEnd: number,
+  ): number {
+    return Math.max(
+      this.getChunkChannelIndex(channelStart),
+      this.getChunkChannelIndex(channelEnd - 1),
+    );
   }
 
   private async loadChunk(
@@ -284,9 +333,12 @@ export class ChunkedTimeseriesClient {
     channelEnd: number,
   ) {
     const startChunkIndex = this.getChunkTimeIndex(tStart);
-    const endChunkIndex = this.getChunkTimeIndex(tEnd);
+    const endChunkIndex = this.getLastChunkTimeIndex(tStart, tEnd);
     const startChannelIndex = this.getChunkChannelIndex(channelStart);
-    const endChannelIndex = this.getChunkChannelIndex(channelEnd);
+    const endChannelIndex = this.getLastChunkChannelIndex(
+      channelStart,
+      channelEnd,
+    );
 
     await this.ensureChunksLoaded(
       startChunkIndex,
@@ -306,9 +358,16 @@ export class ChunkedTimeseriesClient {
       for (let j = startChannelIndex; j <= endChannelIndex; j++) {
         const chunkKey = `${i}-${j}`;
         const chunk = this.chunks.get(chunkKey)!;
+        // Each sample belongs to exactly one chunk by its timestamp, so
+        // restrict to this chunk's own interval as well as the request.
+        const tStartChunk = Math.max(tStart, chunk.startTime);
+        const tEndChunk = Math.min(tEnd, chunk.endTime);
         const timeIndsToUse = [];
         for (let k = 0; k < chunk.timestamps.length; k++) {
-          if (chunk.timestamps[k] >= tStart && chunk.timestamps[k] < tEnd) {
+          if (
+            chunk.timestamps[k] >= tStartChunk &&
+            chunk.timestamps[k] < tEndChunk
+          ) {
             timeIndsToUse.push(k);
           }
         }


### PR DESCRIPTION
Fixes #466.

`TimeseriesClient.getDataForTimeRange` and `DirectSpikeTrainsClient.getUnitSpikeTrainForTimeRange` both resolved the end of a time range to the nearest sample index and used it as an exclusive bound. When the nearest sample sat just below the boundary it was dropped, and since the nearest index clamps to `length - 1` past the end, the last sample of every series and the last spike of every unit were never loaded. In the chunked clients this repeated at every chunk edge.

Both clients now load through the sample after the nearest index and keep exactly the samples whose timestamps lie in `[tStart, tEnd)`. `ChunkedTimeseriesClient` also filters each chunk by its own interval intersected with the request, so a sample belongs to exactly one chunk and cannot be duplicated, and it computes the last chunk index from the exclusive end so a range ending on a boundary no longer loads the next chunk, or a zero-width channel slice when the channel range ends on a chunk boundary. The spike-train `TimestampFinder` gains a `length` getter for the clamp.

Tests: `TimeseriesClient.test.ts` and `DirectSpikeTrainsClient.test.ts` mock `@hdf5Interface` with in-memory datasets. They check that a 25-sample regular series returns all 25 samples, that the sample just below a chunk boundary and the last sample survive, that assembling across boundaries produces no duplicates and matches a piecewise load, that no extra chunk or channel slice is requested, and the same for an irregular series. The spike tests use two ragged units and check the last spike, boundary spikes, no duplicates, in-chunk ranges, and that reads stay within the unit's own slice. Eight of the fourteen cases fail on the previous code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c