### PR TITLE
Cancel superseded async loads in data hooks and views

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.17.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.3",
         "@types/pako": "^2.0.3",
         "@types/react": "^18.3.18",
         "@types/react-dom": "^18.3.5",
@@ -44,11 +46,65 @@
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.16",
         "globals": "^15.14.0",
+        "jsdom": "^30.0.1",
         "prettier": "^3.3.2",
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.18.2",
         "vite": "^6.0.5",
         "vitest": "^4.1.10"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -538,6 +594,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
     "node_modules/@choojs/findup": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@choojs/findup/-/findup-0.2.1.tgz",
@@ -549,6 +618,146 @@
       },
       "bin": {
         "findup": "bin/findup.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.2.tgz",
+      "integrity": "sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.12.tgz",
+      "integrity": "sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -1294,6 +1503,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@fi-sci/misc": {
@@ -2653,6 +2880,89 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.3.tgz",
+      "integrity": "sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -2735,6 +3045,13 @@
       "funding": {
         "url": "https://opencollective.com/turf"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3629,7 +3946,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3682,6 +3998,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/array-bounds": {
       "version": "1.0.1",
@@ -3948,6 +4274,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-search-bounds": {
@@ -4648,6 +4984,20 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/csscolorparser": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
@@ -4833,6 +5183,58 @@
         "node": ">= 14"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4958,6 +5360,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -5086,6 +5495,19 @@
       "peer": true,
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -6704,6 +7126,19 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -7109,6 +7544,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-string-blank": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-string-blank/-/is-string-blank-1.0.1.tgz",
@@ -7402,6 +7844,95 @@
       "license": "0BSD",
       "peer": true
     },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -7623,6 +8154,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -8140,6 +8681,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/memoize-one": {
       "version": "5.2.1",
@@ -9648,6 +10196,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -10805,6 +11366,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -10956,6 +11527,19 @@
       "peer": true,
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -11598,6 +12182,13 @@
         "svg-path-bounds": "^1.0.1"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/terser": {
       "version": "5.46.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
@@ -11720,6 +12311,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -11780,6 +12391,19 @@
         "topo2geo": "bin/topo2geo",
         "topomerge": "bin/topomerge",
         "topoquantize": "bin/topoquantize"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/tr46": {
@@ -11930,6 +12554,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
+      "integrity": "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -12331,6 +12965,19 @@
         "pbf": "^3.2.1"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -12370,6 +13017,16 @@
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -12540,6 +13197,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.3",
     "@types/pako": "^2.0.3",
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
@@ -49,6 +51,7 @@
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.16",
     "globals": "^15.14.0",
+    "jsdom": "^30.0.1",
     "prettier": "^3.3.2",
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.18.2",

--- a/src/pages/NwbPage/MainWorkspace.tsx
+++ b/src/pages/NwbPage/MainWorkspace.tsx
@@ -145,8 +145,11 @@ const MainWorkspace: React.FC<MainWorkspaceProps> = ({
 
   // Check if /units exists
   useEffect(() => {
+    setDefaultUnitsPath(undefined);
+    let canceled = false;
     const checkUnits = async () => {
       const group = await getHdf5Group(nwbUrl, "/units");
+      if (canceled) return;
       // No specifications available here (the provider is set up below this
       // component), so this falls back to the known core type relationships
       if (
@@ -156,7 +159,12 @@ const MainWorkspace: React.FC<MainWorkspaceProps> = ({
         setDefaultUnitsPath("/units");
       }
     };
-    checkUnits();
+    checkUnits().catch((err) => {
+      if (!canceled) console.error(err);
+    });
+    return () => {
+      canceled = true;
+    };
   }, [nwbUrl]);
 
   // Check for authentication errors

--- a/src/pages/NwbPage/NwbHierarchyView.tsx
+++ b/src/pages/NwbPage/NwbHierarchyView.tsx
@@ -84,6 +84,7 @@ const NwbHierarchyView: FunctionComponent<Props> = ({
   const specifications = useNwbFileSpecifications();
 
   useEffect(() => {
+    let canceled = false;
     const loadLaunchablePlugins = async () => {
       const newLaunchablePluginsWithSecondaryPaths: {
         [key: string]: {
@@ -103,6 +104,7 @@ const NwbHierarchyView: FunctionComponent<Props> = ({
             defaultUnitsPath,
           },
         );
+        if (canceled) return;
         if (plugins.length > 0) {
           newLaunchablePluginsWithSecondaryPaths[obj.path] = plugins.map(
             (plugin) => ({
@@ -114,14 +116,21 @@ const NwbHierarchyView: FunctionComponent<Props> = ({
           );
         }
       }
+      if (canceled) return;
       setLaunchablePluginsWithSecondaryPaths(
         newLaunchablePluginsWithSecondaryPaths,
       );
     };
-    loadLaunchablePlugins();
+    loadLaunchablePlugins().catch((err) => {
+      if (!canceled) console.error(err);
+    });
+    return () => {
+      canceled = true;
+    };
   }, [nwbUrl, neurodataObjects, defaultUnitsPath, specifications]);
 
   useEffect(() => {
+    let canceled = false;
     const checkInteractiveViews = async () => {
       const interactivePaths = new Set<string>();
       for (const obj of neurodataObjects) {
@@ -133,6 +142,7 @@ const NwbHierarchyView: FunctionComponent<Props> = ({
           objectType,
           { specifications },
         );
+        if (canceled) return;
         const hasInteractive = plugins.some(
           (p) => p.name !== "default" && p.name !== "PythonScript",
         );
@@ -140,9 +150,15 @@ const NwbHierarchyView: FunctionComponent<Props> = ({
           interactivePaths.add(obj.path);
         }
       }
+      if (canceled) return;
       setObjectsWithInteractiveViews(interactivePaths);
     };
-    checkInteractiveViews();
+    checkInteractiveViews().catch((err) => {
+      if (!canceled) console.error(err);
+    });
+    return () => {
+      canceled = true;
+    };
   }, [nwbUrl, neurodataObjects, specifications]);
 
   const truncateDescription = useCallback(

--- a/src/pages/NwbPage/NwbObjectView.tsx
+++ b/src/pages/NwbPage/NwbObjectView.tsx
@@ -31,27 +31,34 @@ const NwbObjectView: React.FC<NwbObjectViewProps> = ({
   height,
   inMultiView,
 }) => {
-  const [plugins, setPlugins] = useState<NwbObjectViewPlugin[] | undefined>();
-  const [loading, setLoading] = useState(true);
+  // The plugins resolved so far, tagged with the object they were resolved
+  // for. When only the specifications change (they arrive after the first
+  // render) the previously resolved plugins stay mounted while the new
+  // resolution runs, so open views keep their state instead of remounting.
+  const objectKey = `${nwbUrl}|${path}|${objectType}|${plugin?.name ?? ""}|${
+    inMultiView ? 1 : 0
+  }`;
+  const [resolved, setResolved] = useState<{
+    key: string;
+    plugins: NwbObjectViewPlugin[];
+  }>();
 
   const specifications = useNwbFileSpecifications();
 
   useEffect(() => {
     if (plugin) {
-      setPlugins([plugin]);
-      setLoading(false);
+      setResolved({ key: objectKey, plugins: [plugin] });
       return;
     }
+    let canceled = false;
     const loadPlugin = async () => {
-      setLoading(true);
       try {
-        if (plugin) {
-          setPlugins([plugin]);
-        } else {
+        {
           let suitable = await findSuitablePlugins(nwbUrl, path, objectType, {
             specifications,
             launchableFromTable: false,
           });
+          if (canceled) return;
           {
             // only include plugins that do not have hideFromObjectView set to true
             const suitable2 = suitable.filter(
@@ -70,24 +77,32 @@ const NwbObjectView: React.FC<NwbObjectViewProps> = ({
             }
             suitable = suitable2;
           }
-          setPlugins(suitable);
+          setResolved({ key: objectKey, plugins: suitable });
         }
       } catch (err) {
+        if (canceled) return;
         console.error("Error finding suitable plugin:", err);
-      } finally {
-        setLoading(false);
+        setResolved({ key: objectKey, plugins: [] });
       }
     };
     loadPlugin();
-  }, [path, objectType, nwbUrl, plugin, inMultiView, specifications]);
+    return () => {
+      canceled = true;
+    };
+  }, [
+    path,
+    objectType,
+    nwbUrl,
+    plugin,
+    inMultiView,
+    specifications,
+    objectKey,
+  ]);
 
-  if (loading) {
+  if (!resolved || resolved.key !== objectKey) {
     return <CircularProgress />;
   }
-
-  if (!plugins) {
-    throw new Error("Plugins is undefined");
-  }
+  const plugins = resolved.plugins;
 
   if (plugins.length === 0) {
     return <div>Error: No suitable plugin found</div>;

--- a/src/pages/NwbPage/hdf5Interface.ts
+++ b/src/pages/NwbPage/hdf5Interface.ts
@@ -365,14 +365,25 @@ export const getHdf5DatasetData = async (
   }
 };
 
+// The hooks below clear their state when the url or path changes and ignore
+// the result of a load that was superseded, so a slow response for a
+// previous object cannot be shown for the current one.
 export const useHdf5Group = (url: string, path: string) => {
   const [group, setGroup] = useState<Hdf5Group | undefined>(undefined);
   useEffect(() => {
+    setGroup(undefined);
+    let canceled = false;
     const load = async () => {
       const g = await getHdf5Group(url, path);
+      if (canceled) return;
       setGroup(g);
     };
-    load();
+    load().catch((err) => {
+      if (!canceled) console.error(`Error loading group ${path}:`, err);
+    });
+    return () => {
+      canceled = true;
+    };
   }, [url, path]);
   return group;
 };
@@ -380,11 +391,19 @@ export const useHdf5Group = (url: string, path: string) => {
 export const useHdf5Dataset = (url: string, path: string) => {
   const [dataset, setDataset] = useState<Hdf5Dataset | undefined>(undefined);
   useEffect(() => {
+    setDataset(undefined);
+    let canceled = false;
     const load = async () => {
       const d = await getHdf5Dataset(url, path);
+      if (canceled) return;
       setDataset(d);
     };
-    load();
+    load().catch((err) => {
+      if (!canceled) console.error(`Error loading dataset ${path}:`, err);
+    });
+    return () => {
+      canceled = true;
+    };
   }, [url, path]);
   return dataset;
 };
@@ -395,19 +414,26 @@ export const useHdf5DatasetData = (url: string, path: string) => {
     undefined,
   );
   useEffect(() => {
+    setData(undefined);
+    setErrorMessage(undefined);
+    let canceled = false;
     const load = async () => {
-      setData(undefined);
       let d;
       try {
         d = await getHdf5DatasetData(url, path, {});
       } catch (err: any) {
+        if (canceled) return;
         console.error(`Error loading dataset data: ${err.message}`);
         setErrorMessage(err.message);
         return;
       }
+      if (canceled) return;
       setData(d);
     };
     load();
+    return () => {
+      canceled = true;
+    };
   }, [url, path]);
   return { data, errorMessage };
 };

--- a/src/pages/NwbPage/plugins/ImageSegmentation/ImageSegmentationItemView/PlaneSegmentationView.tsx
+++ b/src/pages/NwbPage/plugins/ImageSegmentation/ImageSegmentationItemView/PlaneSegmentationView.tsx
@@ -330,6 +330,7 @@ const Test1: FunctionComponent<{
           );
         } else if (client.hasPixelMask) {
           const aa = await client.getPixelMask(j);
+          if (canceled) return;
           if (!aa) throw Error(`Unable to load pixel mask data`);
           const values: { x: number; y: number; v: number }[] = [];
           for (let i = 0; i < aa.length; i++) {

--- a/src/pages/NwbPage/plugins/Raster/RasterView.tsx
+++ b/src/pages/NwbPage/plugins/Raster/RasterView.tsx
@@ -76,21 +76,23 @@ const RasterViewChild = ({
     if (!spikeTrainsClient) return;
     if (visibleStartTimeSec === undefined || visibleDuration === undefined)
       return;
+    let canceled = false;
     setIsLoading(true);
     const load = async () => {
       const unitIds = spikeTrainsClient.unitIds.slice(
         visibleUnitsStart,
         visibleUnitsStart + numVisibleUnits,
       );
-      const spikeTimes: number[][] = [];
-      for (const unitId of unitIds) {
-        const spikes = await spikeTrainsClient.getUnitSpikeTrainForTimeRange(
-          unitId,
-          visibleStartTimeSec,
-          visibleStartTimeSec + visibleDuration,
-        );
-        spikeTimes.push(spikes);
-      }
+      const spikeTimes = await Promise.all(
+        unitIds.map((unitId) =>
+          spikeTrainsClient.getUnitSpikeTrainForTimeRange(
+            unitId,
+            visibleStartTimeSec,
+            visibleStartTimeSec + visibleDuration,
+          ),
+        ),
+      );
+      if (canceled) return;
       setPlotData({
         unitIds: unitIds.map((id) => id.toString()),
         spikeTimes,
@@ -100,7 +102,14 @@ const RasterViewChild = ({
       });
       setIsLoading(false);
     };
-    load();
+    load().catch((err) => {
+      if (canceled) return;
+      console.error(err);
+      setIsLoading(false);
+    });
+    return () => {
+      canceled = true;
+    };
   }, [
     visibleStartTimeSec,
     visibleDuration,
@@ -274,15 +283,24 @@ const useDirectSpikeTrainsClient = (nwbUrl: string, path: string) => {
     useState<ChunkedDirectSpikeTrainsClient | null>(null);
 
   useEffect(() => {
+    setSpikeTrainsClient(null);
+    let canceled = false;
     const create = async () => {
       const client = await ChunkedDirectSpikeTrainsClient.create(
         nwbUrl,
         path,
         blockSizeSec,
       );
+      if (canceled) return;
       setSpikeTrainsClient(client);
     };
-    create();
+    create().catch((err) => {
+      if (canceled) return;
+      console.error(err);
+    });
+    return () => {
+      canceled = true;
+    };
   }, [nwbUrl, path]);
 
   return spikeTrainsClient;

--- a/src/pages/NwbPage/plugins/simple-timeseries/hooks.test.tsx
+++ b/src/pages/NwbPage/plugins/simple-timeseries/hooks.test.tsx
@@ -176,17 +176,19 @@ describe("useTimeseriesClient", () => {
     await flush();
     expect(creates.map((c) => c.path)).toEqual(["/a", "/b"]);
 
-    const clientB = makeClient("/b");
-    const clientA = makeClient("/a");
+    const clientForB = makeClient("/b");
+    const clientForA = makeClient("/a");
     await act(async () => {
-      creates[1].d.resolve(clientB);
+      creates[1].d.resolve(clientForB);
     });
-    await waitFor(() => expect(result.current.timeseriesClient).toBe(clientB));
+    await waitFor(() =>
+      expect(result.current.timeseriesClient).toBe(clientForB),
+    );
     await act(async () => {
-      creates[0].d.resolve(clientA);
+      creates[0].d.resolve(clientForA);
     });
     await flush();
-    expect(result.current.timeseriesClient).toBe(clientB);
+    expect(result.current.timeseriesClient).toBe(clientForB);
   });
 
   it("clears the previous client while the next one is created", async () => {

--- a/src/pages/NwbPage/plugins/simple-timeseries/hooks.test.tsx
+++ b/src/pages/NwbPage/plugins/simple-timeseries/hooks.test.tsx
@@ -1,0 +1,206 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ProvideTimeseriesSelection,
+  useTimeseriesSelection,
+} from "@shared/context-timeseries-selection-2";
+
+// A deferred promise so the test decides when each load resolves.
+const deferred = <T,>() => {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+type LoadResult = { timestamps: number[]; data: number[][] };
+const loads: {
+  tStart: number;
+  tEnd: number;
+  d: ReturnType<typeof deferred<LoadResult>>;
+}[] = [];
+
+const groups: { [path: string]: object } = {
+  "/a": { path: "/a", datasets: [], subgroups: [], attrs: {} },
+  "/b": { path: "/b", datasets: [], subgroups: [], attrs: {} },
+};
+const creates: { path: string; d: ReturnType<typeof deferred<unknown>> }[] = [];
+
+const makeClient = (path: string) => ({
+  path,
+  startTime: 0,
+  endTime: 100,
+  duration: 100,
+  samplingFrequency: 10,
+  numChannels: 2,
+  numSamples: 1000,
+  chunkSizeSec: 1,
+  getDataForTimeRange: (tStart: number, tEnd: number) => {
+    const d = deferred<LoadResult>();
+    loads.push({ tStart, tEnd, d });
+    return d.promise;
+  },
+});
+
+vi.mock("@hdf5Interface", () => ({
+  useHdf5Group: (_url: string, path: string) => groups[path],
+}));
+
+vi.mock("./TimeseriesClient", () => ({
+  ChunkedTimeseriesClient: {
+    create: (_url: string, group: { path: string }) => {
+      const d = deferred<unknown>();
+      creates.push({ path: group.path, d });
+      return d.promise;
+    },
+  },
+}));
+
+const { useTimeseriesClient, useTimeseriesData } = await import("./hooks");
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <ProvideTimeseriesSelection>{children}</ProvideTimeseriesSelection>
+);
+
+const flush = () => act(() => new Promise((r) => setTimeout(r, 0)));
+
+describe("useTimeseriesData", () => {
+  beforeEach(() => {
+    loads.length = 0;
+    creates.length = 0;
+  });
+
+  it("ignores a stale load that resolves after a newer one", async () => {
+    const { result } = renderHook(
+      () => ({
+        data: useTimeseriesData("u", "/a"),
+        selection: useTimeseriesSelection(),
+      }),
+      { wrapper },
+    );
+    await flush();
+    await act(async () => {
+      creates[0].d.resolve(makeClient("/a"));
+    });
+    await waitFor(() =>
+      expect(result.current.data.timeseriesClient).toBeTruthy(),
+    );
+    // The initial visible range triggers the first load.
+    await waitFor(() => expect(loads.length).toBe(1));
+
+    // Two quick zooms: each starts a new load before the previous resolves.
+    await act(async () => {
+      result.current.selection.setVisibleTimeRange(10.2, 11.5);
+    });
+    await waitFor(() => expect(loads.length).toBe(2));
+    await act(async () => {
+      result.current.selection.setVisibleTimeRange(20.2, 21.5);
+    });
+    await waitFor(() => expect(loads.length).toBe(3));
+    expect(loads[1]).toMatchObject({ tStart: 10, tEnd: 12 });
+    expect(loads[2]).toMatchObject({ tStart: 20, tEnd: 22 });
+
+    // The newest load resolves first, then the superseded ones straggle in.
+    const newest = { timestamps: [20, 21], data: [[200, 210]] };
+    const stale = { timestamps: [10, 11], data: [[100, 110]] };
+    const initial = { timestamps: [0], data: [[0]] };
+    await act(async () => {
+      loads[2].d.resolve(newest);
+    });
+    await waitFor(() =>
+      expect(result.current.data.loadedTimestamps).toEqual([20, 21]),
+    );
+    expect(result.current.data.isLoading).toBe(false);
+
+    await act(async () => {
+      loads[1].d.resolve(stale);
+      loads[0].d.resolve(initial);
+    });
+    await flush();
+    expect(result.current.data.loadedTimestamps).toEqual([20, 21]);
+    expect(result.current.data.loadedData).toEqual([[200, 210]]);
+    expect(result.current.data.isLoading).toBe(false);
+  });
+
+  it("ignores an error from a superseded load", async () => {
+    const { result } = renderHook(
+      () => ({
+        data: useTimeseriesData("u", "/a"),
+        selection: useTimeseriesSelection(),
+      }),
+      { wrapper },
+    );
+    await flush();
+    await act(async () => {
+      creates[0].d.resolve(makeClient("/a"));
+    });
+    await waitFor(() => expect(loads.length).toBe(1));
+    await act(async () => {
+      result.current.selection.setVisibleTimeRange(10.2, 11.5);
+    });
+    await waitFor(() => expect(loads.length).toBe(2));
+    await act(async () => {
+      loads[1].d.resolve({ timestamps: [10], data: [[1]] });
+    });
+    await waitFor(() =>
+      expect(result.current.data.loadedTimestamps).toEqual([10]),
+    );
+    await act(async () => {
+      loads[0].d.reject(new Error("old request failed"));
+    });
+    await flush();
+    expect(result.current.data.error).toBeUndefined();
+    expect(result.current.data.loadedTimestamps).toEqual([10]);
+  });
+});
+
+describe("useTimeseriesClient", () => {
+  beforeEach(() => {
+    loads.length = 0;
+    creates.length = 0;
+  });
+
+  it("does not adopt a client for a path that is no longer shown", async () => {
+    const { result, rerender } = renderHook(
+      ({ path }: { path: string }) => useTimeseriesClient("u", path),
+      { wrapper, initialProps: { path: "/a" } },
+    );
+    await flush();
+    expect(creates.map((c) => c.path)).toEqual(["/a"]);
+    rerender({ path: "/b" });
+    await flush();
+    expect(creates.map((c) => c.path)).toEqual(["/a", "/b"]);
+
+    const clientB = makeClient("/b");
+    const clientA = makeClient("/a");
+    await act(async () => {
+      creates[1].d.resolve(clientB);
+    });
+    await waitFor(() => expect(result.current.timeseriesClient).toBe(clientB));
+    await act(async () => {
+      creates[0].d.resolve(clientA);
+    });
+    await flush();
+    expect(result.current.timeseriesClient).toBe(clientB);
+  });
+
+  it("clears the previous client while the next one is created", async () => {
+    const { result, rerender } = renderHook(
+      ({ path }: { path: string }) => useTimeseriesClient("u", path),
+      { wrapper, initialProps: { path: "/a" } },
+    );
+    await flush();
+    await act(async () => {
+      creates[0].d.resolve(makeClient("/a"));
+    });
+    await waitFor(() => expect(result.current.timeseriesClient).toBeTruthy());
+    rerender({ path: "/b" });
+    await flush();
+    expect(result.current.timeseriesClient).toBeUndefined();
+  });
+});

--- a/src/pages/NwbPage/plugins/simple-timeseries/hooks.ts
+++ b/src/pages/NwbPage/plugins/simple-timeseries/hooks.ts
@@ -13,18 +13,26 @@ export const useTimeseriesClient = (nwbUrl: string, path: string) => {
   const group = useHdf5Group(nwbUrl, path);
 
   useEffect(() => {
+    setTimeseriesClient(undefined);
+    setError(undefined);
     if (!group) return;
+    let canceled = false;
     const load = async () => {
       try {
         const client = await ChunkedTimeseriesClient.create(nwbUrl, group, {
           chunkSizeSec: 1,
         });
+        if (canceled) return;
         setTimeseriesClient(client);
       } catch (err: any) {
+        if (canceled) return;
         setError(err.message);
       }
     };
     load();
+    return () => {
+      canceled = true;
+    };
   }, [nwbUrl, group]);
 
   return { timeseriesClient, error };
@@ -173,10 +181,13 @@ export const useTimeseriesData = (
     numVisibleChannels,
   ]);
 
-  // Load data when view parameters change
+  // Load data when view parameters change. A load that is superseded by a
+  // newer one (the user zooms twice quickly) must not overwrite the newer
+  // result when it eventually resolves, so each run is canceled on cleanup.
   useEffect(() => {
     if (!timeseriesClient) return;
     if (zoomInRequired) return;
+    let canceled = false;
     setIsLoading(true);
     const load = async () => {
       if (bufferedVisibleStartTimeSec === undefined) return;
@@ -192,15 +203,20 @@ export const useTimeseriesData = (
         visibleChannelsStart,
         visibleChannelsEnd,
       );
+      if (canceled) return;
       setLoadedTimestamps(timestamps);
       setLoadedData(data);
       setIsLoading(false);
     };
     load().catch((err) => {
+      if (canceled) return;
       console.error(err);
       setError(err.message);
       setIsLoading(false);
     });
+    return () => {
+      canceled = true;
+    };
   }, [
     timeseriesClient,
     bufferedVisibleStartTimeSec,


### PR DESCRIPTION
Fixes #468.

Several effects that load data asynchronously had no cancellation, so a slow response for a superseded request could overwrite newer state: zooming the timeseries plot twice quickly could leave it showing the earlier window, a path change could adopt the client created for the previous path, `NwbObjectView` unmounted and remounted every plugin when the specifications arrived, and the hdf5 hooks kept the previous object's state while the next one loaded.

Each affected effect now sets a `canceled` flag in its cleanup and checks it after every await, clears its state when the object it loads for changes, and catches rejections instead of leaving them unhandled. The sites are the two hooks in `simple-timeseries/hooks.ts`, the spike load and client creation in `RasterView.tsx` (the units are now fetched in parallel), `NwbObjectView.tsx`, both plugin discovery effects in `NwbHierarchyView.tsx`, `useHdf5Group`, `useHdf5Dataset`, and `useHdf5DatasetData` in `hdf5Interface.ts`, the `/units` check in `MainWorkspace.tsx`, and the pixel-mask branch of `PlaneSegmentationView.tsx`.

`NwbObjectView` also changes how it shows its spinner: the resolved plugin list is tagged with the object it was resolved for, and the spinner appears only when nothing has been resolved for the current object. When only the specifications change, the mounted plugins stay in place while the new resolution runs, so a tab opened from a deep link no longer loses its state. A failed resolution now renders the "no suitable plugin" message instead of throwing.

Testing: this adds `jsdom`, `@testing-library/react`, and `@testing-library/dom` as dev dependencies. `hooks.test.tsx` runs under jsdom with the timeseries client and hdf5 interface mocked by deferred promises, and checks that a stale load resolving after a newer one is ignored, that a stale rejection does not set the error, that a client resolving for a path that is no longer shown is not adopted, and that the client is cleared while the next one is created. All four fail on the previous hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c