### PR TITLE
Keep multi-object tab arrays aligned with their items

### DIFF
--- a/src/pages/NwbPage/TabManager/index.ts
+++ b/src/pages/NwbPage/TabManager/index.ts
@@ -3,6 +3,7 @@ import { determineObjectType } from "../ObjectTypeUtils";
 import { NwbObjectViewPlugin } from "../plugins/pluginInterface";
 import { findPluginByName } from "../plugins/registry";
 import tabsReducer from "../tabsReducer";
+import { parseMultiTabItem } from "../multiTabItems";
 import { TabsState } from "../Types";
 
 interface UseTabManagerProps {
@@ -61,12 +62,14 @@ export const useTabManager = ({
             secondaryPaths,
           });
         } else if (initialTabId.startsWith("[")) {
-          const paths = JSON.parse(initialTabId);
+          const items: string[] = JSON.parse(initialTabId);
           const objectTypes = await Promise.all(
-            paths.map((path: string) => determineObjectType(nwbUrl, path)),
+            items.map((item) =>
+              determineObjectType(nwbUrl, parseMultiTabItem(item).path),
+            ),
           );
           if (canceled) return;
-          dispatch({ type: "OPEN_MULTI_TAB", paths, objectTypes });
+          dispatch({ type: "OPEN_MULTI_TAB", paths: items, objectTypes });
         } else {
           const objectType = await determineObjectType(nwbUrl, initialTabId);
           if (canceled) return;
@@ -85,15 +88,21 @@ export const useTabManager = ({
     };
   }, [initialTabId, nwbUrl]);
 
-  const handleOpenObjectsInNewTab = async (paths: string[]) => {
-    if (paths.length === 1) {
-      const objectType = await determineObjectType(nwbUrl, paths[0]);
-      dispatch({ type: "OPEN_TAB", id: paths[0], path: paths[0], objectType });
+  // Items are the strings collected by the hierarchy view: plain paths or
+  // "plugin|path^secondary" entries. Object types are resolved for the path
+  // inside each item, not for the raw string.
+  const handleOpenObjectsInNewTab = async (items: string[]) => {
+    if (items.length === 1) {
+      const path = parseMultiTabItem(items[0]).path;
+      const objectType = await determineObjectType(nwbUrl, path);
+      dispatch({ type: "OPEN_TAB", id: path, path, objectType });
     } else {
       const objectTypes = await Promise.all(
-        paths.map((path) => determineObjectType(nwbUrl, path)),
+        items.map((item) =>
+          determineObjectType(nwbUrl, parseMultiTabItem(item).path),
+        ),
       );
-      dispatch({ type: "OPEN_MULTI_TAB", paths, objectTypes });
+      dispatch({ type: "OPEN_MULTI_TAB", paths: items, objectTypes });
     }
   };
 

--- a/src/pages/NwbPage/multiTabItems.test.ts
+++ b/src/pages/NwbPage/multiTabItems.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { parseMultiTabItem, parseMultiTabItems } from "./multiTabItems";
+
+describe("parseMultiTabItem", () => {
+  it("returns a plain path as is", () => {
+    expect(parseMultiTabItem("/acquisition/ts")).toEqual({
+      path: "/acquisition/ts",
+    });
+  });
+
+  it("splits a plugin item into name, path, and secondary paths", () => {
+    expect(parseMultiTabItem("PSTH|/intervals/trials^/units")).toEqual({
+      path: "/intervals/trials",
+      pluginName: "PSTH",
+      secondaryPaths: ["/units"],
+    });
+  });
+
+  it("gives an empty secondary list to a plugin item without one", () => {
+    expect(parseMultiTabItem("Raster|/units")).toEqual({
+      path: "/units",
+      pluginName: "Raster",
+      secondaryPaths: [],
+    });
+  });
+
+  it("keeps items aligned with the input", () => {
+    const items = parseMultiTabItems(["/a", "PSTH|/b^/units", "/c"]);
+    expect(items.map((i) => i.path)).toEqual(["/a", "/b", "/c"]);
+    expect(items.map((i) => i.pluginName)).toEqual([
+      undefined,
+      "PSTH",
+      undefined,
+    ]);
+  });
+});

--- a/src/pages/NwbPage/multiTabItems.ts
+++ b/src/pages/NwbPage/multiTabItems.ts
@@ -1,0 +1,21 @@
+// A multi-object tab is opened from a list of item strings collected by the
+// hierarchy view's checkboxes. Each is either a plain object path, or
+// "<pluginName>|<path>^<secondaryPath>^..." for a launchable plugin view.
+export type MultiTabItem = {
+  path: string;
+  pluginName?: string;
+  secondaryPaths?: string[];
+};
+
+export const parseMultiTabItem = (itemString: string): MultiTabItem => {
+  const bar = itemString.indexOf("|");
+  if (bar < 0) {
+    return { path: itemString };
+  }
+  const pluginName = itemString.slice(0, bar);
+  const [path, ...secondaryPaths] = itemString.slice(bar + 1).split("^");
+  return { path, pluginName, secondaryPaths };
+};
+
+export const parseMultiTabItems = (itemStrings: string[]): MultiTabItem[] =>
+  itemStrings.map(parseMultiTabItem);

--- a/src/pages/NwbPage/tabsReducer.test.ts
+++ b/src/pages/NwbPage/tabsReducer.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+
+const fakePlugins: { [name: string]: { name: string } } = {
+  PSTH: { name: "PSTH" },
+  Raster: { name: "Raster" },
+};
+vi.mock("./plugins/registry", () => ({
+  findPluginByName: (name: string) => fakePlugins[name],
+}));
+
+const { default: tabsReducer, getPathsAndPlugins } =
+  await import("./tabsReducer");
+
+describe("getPathsAndPlugins", () => {
+  it("keeps plugins and secondary paths aligned with paths", () => {
+    const { paths, plugins, secondaryPathsList } = getPathsAndPlugins([
+      "/acquisition/ts",
+      "PSTH|/intervals/trials^/units",
+      "/processing/behavior",
+      "Raster|/units",
+    ]);
+    expect(paths).toEqual([
+      "/acquisition/ts",
+      "/intervals/trials",
+      "/processing/behavior",
+      "/units",
+    ]);
+    expect(plugins.map((p) => p?.name)).toEqual([
+      undefined,
+      "PSTH",
+      undefined,
+      "Raster",
+    ]);
+    expect(secondaryPathsList).toEqual([undefined, ["/units"], undefined, []]);
+  });
+});
+
+describe("tabsReducer OPEN_MULTI_TAB", () => {
+  it("builds a multi tab whose arrays line up item by item", () => {
+    const state = tabsReducer(
+      { tabs: [], activeTabId: "widgets" },
+      {
+        type: "OPEN_MULTI_TAB",
+        paths: ["/acquisition/ts", "PSTH|/intervals/trials^/units"],
+        objectTypes: ["group", "group"],
+      },
+    );
+    expect(state.tabs).toHaveLength(1);
+    const tab = state.tabs[0];
+    if (tab.type !== "multi") throw new Error("expected a multi tab");
+    expect(tab.paths).toEqual(["/acquisition/ts", "/intervals/trials"]);
+    expect(tab.plugins.map((p) => p?.name)).toEqual([undefined, "PSTH"]);
+    expect(tab.secondaryPathsList).toEqual([undefined, ["/units"]]);
+    expect(tab.objectTypes).toEqual(["group", "group"]);
+    expect(state.activeTabId).toBe(tab.id);
+  });
+
+  it("reactivates an existing tab for the same items", () => {
+    const first = tabsReducer(
+      { tabs: [], activeTabId: "widgets" },
+      {
+        type: "OPEN_MULTI_TAB",
+        paths: ["/a", "/b"],
+        objectTypes: ["group", "dataset"],
+      },
+    );
+    const second = tabsReducer(
+      { ...first, activeTabId: "widgets" },
+      {
+        type: "OPEN_MULTI_TAB",
+        paths: ["/a", "/b"],
+        objectTypes: ["group", "dataset"],
+      },
+    );
+    expect(second.tabs).toHaveLength(1);
+    expect(second.activeTabId).toBe(first.tabs[0].id);
+  });
+});

--- a/src/pages/NwbPage/tabsReducer.ts
+++ b/src/pages/NwbPage/tabsReducer.ts
@@ -1,6 +1,7 @@
 import { BaseTab } from "@components/tabs/tabsReducer";
 import { NwbObjectViewPlugin } from "./plugins/pluginInterface";
 import { findPluginByName } from "./plugins/registry";
+import { parseMultiTabItems } from "./multiTabItems";
 
 type MainTab = BaseTab & {
   type: "main";
@@ -140,23 +141,20 @@ const tabsReducer = (state: TabsState, action: TabsAction): TabsState => {
   }
 };
 
-const getPathsAndPlugins = (itemStrings: string[]) => {
+// The three arrays are index-aligned with the item strings, so a plain path
+// contributes an undefined plugin and undefined secondary paths.
+export const getPathsAndPlugins = (itemStrings: string[]) => {
   const paths: string[] = [];
   const plugins: (NwbObjectViewPlugin | undefined)[] = [];
   const secondaryPathsList: (string[] | undefined)[] = [];
-  for (const itemString of itemStrings) {
-    const a = itemString.split("|");
-    if (a.length <= 1) {
-      paths.push(itemString);
-      plugins.push(undefined);
-    } else {
-      const b = a[1].split("^");
-      paths.push(b[0]);
-      const s = b.slice(1); // todo: use this
-      const p = findPluginByName(a[0]);
-      plugins.push(p);
-      secondaryPathsList.push(s);
-    }
+  for (const item of parseMultiTabItems(itemStrings)) {
+    paths.push(item.path);
+    plugins.push(
+      item.pluginName !== undefined
+        ? findPluginByName(item.pluginName)
+        : undefined,
+    );
+    secondaryPathsList.push(item.secondaryPaths);
   }
   return { paths, plugins, secondaryPathsList };
 };


### PR DESCRIPTION
Fixes #472.

Opening several checked items from the hierarchy view built a multi-object tab whose `secondaryPathsList` was shorter than `paths` and `plugins`, because `getPathsAndPlugins` only appended to it for plugin items. A selection of a plain path plus a PSTH view therefore gave the PSTH entry no units path. Separately, the tab manager passed the raw `plugin|path^secondary` strings to `determineObjectType`, which logged "Parent group not found" and returned `group` for every such item.

The item format now has one parser, `parseMultiTabItem` in `multiTabItems.ts`, used by the reducer and by both places in the tab manager that resolve object types. The reducer keeps the three arrays index-aligned, with `undefined` plugin and secondary paths for plain paths, and `getPathsAndPlugins` is exported for testing.

Tests: `multiTabItems.test.ts` covers plain paths, plugin items with and without secondary paths, and alignment across a list; `tabsReducer.test.ts` mocks the plugin registry and checks that `OPEN_MULTI_TAB` produces aligned arrays for a mixed selection and reactivates an existing tab for the same items. The two alignment tests fail on the previous reducer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c