### PR TITLE
Sync the active tab to the URL through react-router

### DIFF
--- a/src/pages/NwbPage/MainWorkspace.tsx
+++ b/src/pages/NwbPage/MainWorkspace.tsx
@@ -1,11 +1,4 @@
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-  lazy,
-  Suspense,
-} from "react";
+import React, { useEffect, useMemo, useState, lazy, Suspense } from "react";
 import {
   FixedTab,
   TabBar,
@@ -28,6 +21,7 @@ import NwbUsageScript from "./components/NwbUsageScript";
 import MultiVideoTabView from "./MultiVideoTabView";
 import IcephysTabView from "./IcephysTabView";
 import { hasExternalVideos } from "./externalVideoUtils";
+import { useSyncTabToUrl } from "./useSyncTabToUrl";
 
 const SpecificationsView = lazy(
   () => import("./SpecificationsView/SpecificationsView"),
@@ -195,19 +189,7 @@ const MainWorkspace: React.FC<MainWorkspaceProps> = ({
     ? tabsState.activeTabId
     : activeFixedTab;
 
-  const updateUrlTab = useCallback((tabId: string) => {
-    const url = new URL(window.location.href);
-    if (tabId === "widgets") {
-      url.searchParams.delete("tab");
-    } else {
-      url.searchParams.set("tab", tabId);
-    }
-    window.history.replaceState({}, "", url.toString());
-  }, []);
-
-  useEffect(() => {
-    updateUrlTab(effectiveActiveTab);
-  }, [effectiveActiveTab, updateUrlTab]);
+  useSyncTabToUrl(effectiveActiveTab);
 
   const handleFixedTabSwitch = (id: string) => {
     setActiveFixedTab(id);

--- a/src/pages/NwbPage/TabManager/index.ts
+++ b/src/pages/NwbPage/TabManager/index.ts
@@ -1,4 +1,4 @@
-import { useEffect, useReducer } from "react";
+import { useEffect, useReducer, useRef } from "react";
 import { determineObjectType } from "../ObjectTypeUtils";
 import { NwbObjectViewPlugin } from "../plugins/pluginInterface";
 import { findPluginByName } from "../plugins/registry";
@@ -30,11 +30,22 @@ export const useTabManager = ({
     tabs: [],
     activeTabId: "widgets",
   });
+  // The tab list as of the latest render, so the effect below can check for
+  // an already open tab without re-running on every state change.
+  const tabsRef = useRef(tabsState.tabs);
+  tabsRef.current = tabsState.tabs;
 
+  // Open the tab named by the URL. The URL is kept in sync with the active
+  // tab, so this also runs when the user switches tabs; a tab that is
+  // already open is simply activated without any lookups.
   useEffect(() => {
     let canceled = false;
     const load = async () => {
       if (initialTabId) {
+        if (tabsRef.current.some((t) => t.id === initialTabId)) {
+          dispatch({ type: "SWITCH_TO_TAB", id: initialTabId });
+          return;
+        }
         if (initialTabId.startsWith("view:")) {
           const a = initialTabId.split("|");
           if (a.length !== 2) {

--- a/src/pages/NwbPage/TabManager/useTabManager.test.tsx
+++ b/src/pages/NwbPage/TabManager/useTabManager.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const lookups: string[] = [];
+vi.mock("../ObjectTypeUtils", () => ({
+  determineObjectType: async (_url: string, path: string) => {
+    lookups.push(path);
+    return "group";
+  },
+}));
+vi.mock("../plugins/registry", () => ({
+  findPluginByName: (name: string) => ({ name }),
+}));
+
+const { useTabManager } = await import("./index");
+
+describe("useTabManager", () => {
+  it("opens the tab named by the URL and activates it again without a lookup", async () => {
+    lookups.length = 0;
+    const { result, rerender } = renderHook(
+      ({ initialTabId }: { initialTabId?: string }) =>
+        useTabManager({ nwbUrl: "u", initialTabId }),
+      { initialProps: { initialTabId: "/acquisition/a" } },
+    );
+    await waitFor(() =>
+      expect(
+        result.current.tabsState.tabs.map((t: { id: string }) => t.id),
+      ).toEqual(["/acquisition/a"]),
+    );
+    expect(lookups).toEqual(["/acquisition/a"]);
+
+    await act(async () => {
+      await result.current.handleOpenObjectInNewTab("/acquisition/b");
+    });
+    expect(result.current.tabsState.activeTabId).toBe("/acquisition/b");
+    expect(lookups).toEqual(["/acquisition/a", "/acquisition/b"]);
+
+    // The URL follows the active tab, so opening the second tab and then
+    // switching back to the first arrive here as changes to initialTabId.
+    rerender({ initialTabId: "/acquisition/b" });
+    await waitFor(() =>
+      expect(result.current.tabsState.activeTabId).toBe("/acquisition/b"),
+    );
+    rerender({ initialTabId: "/acquisition/a" });
+    await waitFor(() =>
+      expect(result.current.tabsState.activeTabId).toBe("/acquisition/a"),
+    );
+    expect(result.current.tabsState.tabs).toHaveLength(2);
+    expect(lookups).toEqual(["/acquisition/a", "/acquisition/b"]);
+  });
+
+  it("does nothing for a fixed tab id passed as undefined", async () => {
+    lookups.length = 0;
+    const { result } = renderHook(
+      ({ initialTabId }: { initialTabId?: string }) =>
+        useTabManager({ nwbUrl: "u", initialTabId }),
+      { initialProps: { initialTabId: undefined } },
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    expect(result.current.tabsState.tabs).toHaveLength(0);
+    expect(lookups).toEqual([]);
+  });
+});

--- a/src/pages/NwbPage/useSyncTabToUrl.test.tsx
+++ b/src/pages/NwbPage/useSyncTabToUrl.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { act, renderHook } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter, useSearchParams } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+import { useSyncTabToUrl } from "./useSyncTabToUrl";
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MemoryRouter initialEntries={["/nwb?url=https://example.org/f.nwb"]}>
+    {children}
+  </MemoryRouter>
+);
+
+// A stand-in for a child view that rewrites the search params from the
+// router's copy, the way the icephys and video views do.
+const useHookAndParams = ({ tab }: { tab: string }) => {
+  useSyncTabToUrl(tab);
+  const [searchParams, setSearchParams] = useSearchParams();
+  return { searchParams, setSearchParams };
+};
+
+describe("useSyncTabToUrl", () => {
+  it("omits the tab parameter for the widgets tab", () => {
+    const { result } = renderHook(useHookAndParams, {
+      wrapper,
+      initialProps: { tab: "widgets" },
+    });
+    expect(result.current.searchParams.get("tab")).toBeNull();
+    expect(result.current.searchParams.get("url")).toBe(
+      "https://example.org/f.nwb",
+    );
+  });
+
+  it("writes the active tab where the router can see it", () => {
+    const { result, rerender } = renderHook(useHookAndParams, {
+      wrapper,
+      initialProps: { tab: "widgets" },
+    });
+    rerender({ tab: "video-widget" });
+    expect(result.current.searchParams.get("tab")).toBe("video-widget");
+    expect(result.current.searchParams.get("url")).toBe(
+      "https://example.org/f.nwb",
+    );
+    rerender({ tab: "widgets" });
+    expect(result.current.searchParams.get("tab")).toBeNull();
+  });
+
+  it("survives another view rewriting the params from the router's copy", () => {
+    const { result, rerender } = renderHook(useHookAndParams, {
+      wrapper,
+      initialProps: { tab: "icephys" },
+    });
+    expect(result.current.searchParams.get("tab")).toBe("icephys");
+    act(() => {
+      result.current.setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.set("icephysLockY", "1");
+          return next;
+        },
+        { replace: true },
+      );
+    });
+    expect(result.current.searchParams.get("icephysLockY")).toBe("1");
+    expect(result.current.searchParams.get("tab")).toBe("icephys");
+    rerender({ tab: "icephys" });
+    expect(result.current.searchParams.get("tab")).toBe("icephys");
+  });
+});

--- a/src/pages/NwbPage/useSyncTabToUrl.ts
+++ b/src/pages/NwbPage/useSyncTabToUrl.ts
@@ -1,0 +1,27 @@
+import { useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+
+// Mirrors the active tab into the ?tab= search parameter, omitting it for
+// the default Widgets tab. This goes through react-router rather than
+// history.replaceState so that other views which rewrite the search params
+// from the router's copy (the icephys and video views) see the current tab
+// and keep it, instead of dropping it from a stale copy.
+export const useSyncTabToUrl = (tabId: string) => {
+  const [, setSearchParams] = useSearchParams();
+  useEffect(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (tabId === "widgets") {
+          if (!next.has("tab")) return prev;
+          next.delete("tab");
+        } else {
+          if (next.get("tab") === tabId) return prev;
+          next.set("tab", tabId);
+        }
+        return next;
+      },
+      { replace: true },
+    );
+  }, [tabId, setSearchParams]);
+};


### PR DESCRIPTION
Fixes #474.

Stacked on #469, which adds the jsdom test setup this PR's tests use; the base will move to `main` once that merges.

`MainWorkspace` wrote the `?tab=` parameter with `history.replaceState`, which react-router never sees. The icephys and video views build their URL updates from the router's copy of the search params, so their first write dropped the tab parameter and a refresh went back to Widgets.

The sync is now a small hook, `useSyncTabToUrl`, that calls `setSearchParams` in its functional form with `replace: true`, so all writers share one source of truth. It omits the parameter for the Widgets tab and leaves the params untouched when they already match.

Because the URL now feeds back into the `initialTabId` prop on every tab switch, `useTabManager` keeps a ref to the current tab list and, when the id names a tab that is already open, dispatches a switch directly instead of running `determineObjectType` and re-dispatching an open.

Tests: `useSyncTabToUrl.test.tsx` renders the hook inside a `MemoryRouter` next to a sibling `useSearchParams` and checks that the tab is written where the sibling sees it, omitted for Widgets, and preserved when the sibling rewrites the params the way the icephys view does. `useTabManager.test.tsx` checks that an open tab is reactivated without a lookup and that an undefined id does nothing; the first fails on the previous tab manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c