### PR TITLE
Recognize series by type in the Timeseries Alignment view

### DIFF
--- a/src/pages/NwbPage/TimeseriesAlignmentView.test.tsx
+++ b/src/pages/NwbPage/TimeseriesAlignmentView.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+import { render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// A file with an ElectricalSeries (no subgroups) and a TwoPhotonSeries whose
+// imaging_plane link the reader lists as a subgroup.
+type G = {
+  attrs: { [k: string]: unknown };
+  subgroups: string[];
+  datasets: {
+    name: string;
+    shape: number[];
+    attrs?: { [k: string]: unknown };
+  }[];
+};
+const groups: { [path: string]: G } = {
+  "/": { attrs: {}, subgroups: ["acquisition", "general"], datasets: [] },
+  "/general": { attrs: {}, subgroups: [], datasets: [] },
+  "/acquisition": { attrs: {}, subgroups: ["es", "tps"], datasets: [] },
+  "/acquisition/es": {
+    attrs: { neurodata_type: "ElectricalSeries" },
+    subgroups: [],
+    datasets: [
+      { name: "data", shape: [100, 4] },
+      { name: "timestamps", shape: [100] },
+    ],
+  },
+  "/acquisition/tps": {
+    attrs: { neurodata_type: "TwoPhotonSeries" },
+    subgroups: ["imaging_plane"],
+    datasets: [
+      { name: "data", shape: [50, 8, 8] },
+      { name: "starting_time", shape: [], attrs: { rate: 5 } },
+    ],
+  },
+  "/acquisition/tps/imaging_plane": {
+    attrs: { neurodata_type: "ImagingPlane" },
+    subgroups: [],
+    datasets: [],
+  },
+};
+const visited: string[] = [];
+
+vi.mock("./hdf5Interface", () => ({
+  getHdf5Group: async (_url: string, path: string) => {
+    const g = groups[path];
+    if (!g) return undefined;
+    visited.push(path);
+    const prefix = path === "/" ? "" : path;
+    return {
+      path,
+      attrs: g.attrs,
+      subgroups: g.subgroups.map((n) => ({
+        name: n,
+        path: `${prefix}/${n}`,
+        attrs: groups[`${prefix}/${n}`]?.attrs ?? {},
+      })),
+      datasets: g.datasets.map((d) => ({
+        name: d.name,
+        path: `${prefix}/${d.name}`,
+        shape: d.shape,
+        dtype: "<f8",
+        attrs: d.attrs ?? {},
+      })),
+    };
+  },
+  getHdf5DatasetData: async (
+    _url: string,
+    path: string,
+    o: { slice?: [number, number][] },
+  ) => {
+    if (path === "/acquisition/es/timestamps") {
+      const [i] = o.slice![0];
+      return Float64Array.from([i * 0.01]);
+    }
+    if (path === "/acquisition/tps/starting_time") return 2;
+    return undefined;
+  },
+}));
+
+const specs = {
+  subgroups: [],
+  allNamespaces: [],
+  allDatasets: [],
+  allGroups: [
+    {
+      neurodata_type_def: "NWBDataInterface",
+      neurodata_type_inc: "NWBContainer",
+    },
+    {
+      neurodata_type_def: "TimeSeries",
+      neurodata_type_inc: "NWBDataInterface",
+    },
+    {
+      neurodata_type_def: "ElectricalSeries",
+      neurodata_type_inc: "TimeSeries",
+    },
+    { neurodata_type_def: "ImageSeries", neurodata_type_inc: "TimeSeries" },
+    {
+      neurodata_type_def: "TwoPhotonSeries",
+      neurodata_type_inc: "ImageSeries",
+    },
+    { neurodata_type_def: "ImagingPlane", neurodata_type_inc: "NWBContainer" },
+    {
+      neurodata_type_def: "ProcessingModule",
+      neurodata_type_inc: "NWBContainer",
+    },
+  ],
+};
+vi.mock("./SpecificationsView/SetupNwbFileSpecificationsProvider", () => ({
+  useNwbFileSpecifications: () => specs,
+}));
+
+const { default: TimeseriesAlignmentView } =
+  await import("./TimeseriesAlignmentView");
+
+describe("TimeseriesAlignmentView", () => {
+  it("lists series that carry links as subgroups", async () => {
+    const { container } = render(
+      <TimeseriesAlignmentView
+        nwbUrl="u"
+        width={600}
+        isExpanded={true}
+        onOpenTimeseriesItem={() => {}}
+      />,
+    );
+    await waitFor(() => {
+      expect(
+        container.querySelectorAll('[title="ElectricalSeries"]'),
+      ).toHaveLength(1);
+      expect(
+        container.querySelectorAll('[title="TwoPhotonSeries"]'),
+      ).toHaveLength(1);
+    });
+    // The link target is metadata, not a place to look for more series.
+    expect(visited).not.toContain("/acquisition/tps/imaging_plane");
+    expect(visited).not.toContain("/general");
+  });
+});

--- a/src/pages/NwbPage/TimeseriesAlignmentView.tsx
+++ b/src/pages/NwbPage/TimeseriesAlignmentView.tsx
@@ -150,9 +150,13 @@ const TimeseriesAlignmentView: FunctionComponent<Props> = ({
       if (!gr) return;
       try {
         const nt = gr.attrs?.["neurodata_type"];
+        // A series is recognized by its type, not by having no subgroups:
+        // TwoPhotonSeries, PatchClampSeries, OptogeneticSeries, and ImageSeries
+        // carry links to an imaging plane, electrode, site, or device, which
+        // the reader lists as subgroups.
         const isTimeseries =
           nt &&
-          !gr.subgroups?.length &&
+          neurodataTypeInheritsFrom(nt, "TimeSeries", specifications) &&
           gr.datasets?.find((ds: any) => ds.name === "data") &&
           (gr.datasets.find((ds: any) => ds.name === "timestamps") ||
             gr.datasets.find((ds: any) => ds.name === "starting_time"));
@@ -305,6 +309,9 @@ const TimeseriesAlignmentView: FunctionComponent<Props> = ({
             });
           }
         }
+        // A series' subgroups are links to metadata (imaging plane,
+        // electrode, device), never further series, so stop here.
+        if (isTimeseries) return;
         // Recurse into subgroups in parallel, only visiting groups
         // that are relevant data types or containers that hold them
         const { relevantTypes, containerTypes } = typeSets;


### PR DESCRIPTION
Fixes #476.

Stacked on #469 for the jsdom test setup; the base will move to `main` when that merges.

The alignment view required a series to have no subgroups. The LINDI reader lists a series' links as subgroups, so a TwoPhotonSeries with an `imaging_plane`, a PatchClampSeries with an `electrode`, an OptogeneticSeries with a `site`, or an ImageSeries with a `device` was never shown.

A series is now recognized by `neurodataTypeInheritsFrom(nt, "TimeSeries", specifications)` together with a `data` dataset and either `timestamps` or `starting_time`. The traversal also stops at a series rather than descending into its link targets, which are metadata and never contain further series.

Testing: `TimeseriesAlignmentView.test.tsx` mocks the hdf5 interface and the specifications provider, renders the view over a file with an ElectricalSeries and a TwoPhotonSeries carrying an `imaging_plane` subgroup, and checks that both appear and that the imaging plane and `/general` are not visited. The test fails on the previous view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c