### PR TITLE
Resolve LINDI soft links at any prefix of a path

### DIFF
--- a/src/remote-h5-file/lib/lindi/RemoteH5FileLindi.test.ts
+++ b/src/remote-h5-file/lib/lindi/RemoteH5FileLindi.test.ts
@@ -60,6 +60,10 @@ const metadata: { [key: string]: unknown } = {
   "LinkedSeries/.zgroup": { zarr_format: 2 },
   "LinkedSeries/.zattrs": { _SOFT_LINK: { path: "/Corrected" } },
 
+  // A link to a group whose own timestamps child is itself a link.
+  "LinkedDfOverF/.zgroup": { zarr_format: 2 },
+  "LinkedDfOverF/.zattrs": { _SOFT_LINK: { path: "/DfOverF" } },
+
   "BrokenLink/.zgroup": { zarr_format: 2 },
   "BrokenLink/.zattrs": { _SOFT_LINK: { path: "/does/not/exist" } },
 
@@ -74,6 +78,7 @@ const pathsByParentPath: { [key: string]: string[] } = {
     "Corrected",
     "DfOverF",
     "LinkedSeries",
+    "LinkedDfOverF",
     "BrokenLink",
     "CycleA",
     "CycleB",
@@ -146,6 +151,50 @@ describe("RemoteH5FileLindi soft links", () => {
       "data",
       "timestamps",
     ]);
+  });
+
+  it("reports a linked group's children under the link's own path", async () => {
+    const f = createFile();
+    const group = await f.getGroup("/LinkedSeries");
+    expect(group!.path).toBe("/LinkedSeries");
+    expect(group!.datasets.map((ds) => ds.path).sort()).toEqual([
+      "/LinkedSeries/data",
+      "/LinkedSeries/timestamps",
+    ]);
+  });
+
+  it("resolves a link in the middle of a path", async () => {
+    const f = createFile();
+    // LinkedSeries is the link; the dataset below it is a plain dataset of
+    // the target group.
+    const ds = await f.getDataset("/LinkedSeries/timestamps");
+    expect(ds).toBeDefined();
+    expect(ds!.shape).toEqual([10]);
+    expect(ds!.attrs).toEqual({ unit: "seconds", interval: 1 });
+    expect(ds!.path).toBe("/LinkedSeries/timestamps");
+    expect(await f.resolveSoftLink("LinkedSeries/timestamps")).toBe(
+      "Corrected/timestamps",
+    );
+  });
+
+  it("follows a link to a group whose child is itself a link", async () => {
+    const f = createFile();
+    expect(await f.resolveSoftLink("LinkedDfOverF/timestamps")).toBe(
+      "Corrected/timestamps",
+    );
+    const ds = await f.getDataset("/LinkedDfOverF/timestamps");
+    expect(ds!.shape).toEqual([10]);
+    const group = await f.getGroup("/LinkedDfOverF");
+    expect(group!.datasets.map((ds) => ds.name).sort()).toEqual([
+      "data",
+      "timestamps",
+    ]);
+  });
+
+  it("leaves a path with no links unchanged", async () => {
+    const f = createFile();
+    expect(await f.resolveSoftLink("Corrected/data")).toBe("Corrected/data");
+    expect(await f.resolveSoftLink("")).toBe("");
   });
 
   it("falls back to the link itself when the target is missing", async () => {

--- a/src/remote-h5-file/lib/lindi/RemoteH5FileLindi.ts
+++ b/src/remote-h5-file/lib/lindi/RemoteH5FileLindi.ts
@@ -233,17 +233,37 @@ class RemoteH5FileLindi {
   // for .zgroup, .zarray or chunk data. This is common in NWB files: pynwb
   // writes a soft link whenever the same timestamps dataset or rois
   // DynamicTableRegion is shared by more than one TimeSeries.
+  //
+  // A link can sit anywhere in a path, not only at its end: for a linked
+  // group G, the path G/timestamps must resolve to <target of G>/timestamps.
+  // Every prefix is therefore checked, shortest first, and the remainder of
+  // the path is re-attached to the link target. This repeats until no
+  // component is a link, which also follows a link to a group whose own
+  // children are links.
   async resolveSoftLink(pathWithoutBeginningSlash: string): Promise<string> {
     let p = pathWithoutBeginningSlash;
     // guard against a link cycle in a malformed file
-    for (let i = 0; i < maxSoftLinkHops; i++) {
+    for (let hop = 0; hop < maxSoftLinkHops; hop++) {
       if (p === "") return p; // the root group is never a link
-      const zattrs = (await this.lindiFileSystemClient.readJson(
-        p + "/.zattrs",
-      )) as ZMetaDataZAttrs | undefined;
-      const target = zattrs?.["_SOFT_LINK"]?.["path"];
-      if (typeof target !== "string") return p;
-      p = target.startsWith("/") ? target.slice(1) : target;
+      const parts = p.split("/");
+      let redirected = false;
+      for (let i = 1; i <= parts.length; i++) {
+        const prefix = parts.slice(0, i).join("/");
+        const zattrs = (await this.lindiFileSystemClient.readJson(
+          prefix + "/.zattrs",
+        )) as ZMetaDataZAttrs | undefined;
+        const target = zattrs?.["_SOFT_LINK"]?.["path"];
+        if (typeof target !== "string") continue;
+        const targetWithoutSlash = target.startsWith("/")
+          ? target.slice(1)
+          : target;
+        p = [targetWithoutSlash, ...parts.slice(i)]
+          .filter((x) => x !== "")
+          .join("/");
+        redirected = true;
+        break;
+      }
+      if (!redirected) return p;
     }
     console.warn(
       `Too many soft link hops while resolving ${pathWithoutBeginningSlash}`,
@@ -278,6 +298,16 @@ class RemoteH5FileLindi {
       const subdatasets: RemoteH5Subdataset[] = [];
       const childPaths: string[] =
         this.pathsByParentPath[pathWithoutBeginningSlash] || [];
+      // Children are reported under the path that was asked for, so that a
+      // linked group's children carry the link's path (as HDF5 does) and can
+      // be read back through resolveSoftLink.
+      const requestedWithoutSlash =
+        path === "/" ? "" : path.startsWith("/") ? path.slice(1) : path;
+      const childPathUnderRequested = (childPath: string) =>
+        "/" +
+        (requestedWithoutSlash === ""
+          ? getNameFromPath(childPath)
+          : requestedWithoutSlash + "/" + getNameFromPath(childPath));
       for (const childPath of childPaths) {
         // A soft-linked child is reported as the kind of object it points at,
         // with the attributes of that object, but under its own name and path.
@@ -313,7 +343,7 @@ class RemoteH5FileLindi {
           if (shape && dtype) {
             subdatasets.push({
               name: getNameFromPath(childPath),
-              path: "/" + childPath,
+              path: childPathUnderRequested(childPath),
               shape,
               dtype,
               attrs: childZattrs || {},
@@ -331,7 +361,7 @@ class RemoteH5FileLindi {
         } else if (childZgroup) {
           subgroups.push({
             name: getNameFromPath(childPath),
-            path: "/" + childPath,
+            path: childPathUnderRequested(childPath),
             attrs: childZattrs || {},
           });
         }


### PR DESCRIPTION
Fixes #478.

`resolveSoftLink` checked only the requested path's own `.zattrs` for `_SOFT_LINK`. A path such as `/LinkedGroup/timestamps`, where `LinkedGroup` is the link, therefore did not resolve on the LINDI path while it does through h5wasm. Since the timestamps and data clients build `${objectPath}/timestamps`, a series reached through a linked group could not be read from a LINDI file.

The resolver now walks every prefix of the path, shortest first; when a prefix carries a link, the rest of the path is re-attached to the target and the walk restarts, bounded by the existing hop limit. This also handles a link to a group whose own child is a link. `getGroup` reports the children of a linked group under the path that was requested, as HDF5 does, so a child path taken from the group can be read back through the resolver.

Tests extend the existing LINDI fixture with `LinkedDfOverF`, a link to a group whose `timestamps` is itself a link to another series' timestamps, and check: a linked group's children carry the link's path; a mid-path link resolves for `getDataset` and in `resolveSoftLink`; the nested case resolves through both links; plain paths and the root are unchanged. Three of the new cases fail on the previous reader; the seven existing cases still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c