### PR TITLE
Fix EDF reads at the end of a recording and NaN channel separation

### DIFF
--- a/src/shared/EdfViewer/EDFReader.test.ts
+++ b/src/shared/EdfViewer/EDFReader.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import EDFReader from "./EDFReader";
+
+// Build a small EDF file in memory: 16-bit samples, `nRecords` records of
+// one second, each channel with its own samples per record. Sample values
+// encode (channel, index) so that reads can be checked exactly.
+const pad = (s: string, n: number) => (s + " ".repeat(n)).slice(0, n);
+
+const buildEdf = (o: { nRecords: number; nSamps: number[] }) => {
+  const nchan = o.nSamps.length;
+  const headerBytes = 256 + 256 * nchan;
+  let header = "";
+  header += pad("0", 8);
+  header += pad("subject", 80);
+  header += pad("recording", 80);
+  header += pad("01.02.03", 8);
+  header += pad("04.05.06", 8);
+  header += pad(String(headerBytes), 8);
+  header += pad("", 44);
+  header += pad(String(o.nRecords), 8);
+  header += pad("1", 8);
+  header += pad(String(nchan), 4);
+  const per = (f: (ch: number) => string, n: number) => {
+    for (let ch = 0; ch < nchan; ch++) header += pad(f(ch), n);
+  };
+  per((ch) => `ch${ch}`, 16);
+  per(() => "", 80);
+  per(() => "uV", 8);
+  // physical range -1000..1000 over digital -32768..32767, so that
+  // calibration is applied but stays easy to reason about
+  per(() => "-1000", 8);
+  per(() => "1000", 8);
+  per(() => "-32768", 8);
+  per(() => "32767", 8);
+  per(() => "", 80);
+  per((ch) => String(o.nSamps[ch]), 8);
+  per(() => "", 32);
+  if (header.length !== headerBytes) {
+    throw new Error(
+      `header is ${header.length} bytes, expected ${headerBytes}`,
+    );
+  }
+  const recordSamples = o.nSamps.reduce((a, b) => a + b, 0);
+  const buf = new ArrayBuffer(headerBytes + o.nRecords * recordSamples * 2);
+  new Uint8Array(buf).set(new TextEncoder().encode(header), 0);
+  const view = new DataView(buf);
+  let p = headerBytes;
+  for (let r = 0; r < o.nRecords; r++) {
+    for (let ch = 0; ch < nchan; ch++) {
+      for (let i = 0; i < o.nSamps[ch]; i++) {
+        const index = r * o.nSamps[ch] + i;
+        view.setInt16(p, digitalValue(ch, index), true);
+        p += 2;
+      }
+    }
+  }
+  return buf;
+};
+
+// A distinct, small digital value per (channel, index).
+const digitalValue = (ch: number, index: number) => ch * 1000 + index;
+const physicalValue = (ch: number, index: number) => {
+  const cal = 2000 / 65535;
+  const off = -1000 - cal * -32768;
+  return digitalValue(ch, index) * cal + off;
+};
+
+// The reader calibrates in single precision, so compare loosely.
+const expectSamples = (x: Float32Array, expected: number[]) => {
+  expect(x.length).toBe(expected.length);
+  for (let i = 0; i < expected.length; i++) {
+    expect(x[i]).toBeCloseTo(expected[i], 3);
+  }
+};
+
+// Serve the in-memory file over fetch with Range support; record what
+// was asked for so the tests can check that reads stay inside the file.
+const serve = (file: ArrayBuffer) => {
+  const ranges: [number, number][] = [];
+  vi.stubGlobal(
+    "fetch",
+    async (_url: string, init?: { headers?: { Range?: string } }) => {
+      const m = /^bytes=(\d+)-(\d+)$/.exec(init?.headers?.Range ?? "");
+      if (!m) throw new Error("expected a Range header");
+      const start = parseInt(m[1]);
+      const end = parseInt(m[2]);
+      ranges.push([start, end]);
+      if (start >= file.byteLength) {
+        return { ok: false, statusText: "Range Not Satisfiable" };
+      }
+      const body = file.slice(start, Math.min(end + 1, file.byteLength));
+      return {
+        ok: true,
+        statusText: "Partial Content",
+        arrayBuffer: async () => body,
+      };
+    },
+  );
+  return ranges;
+};
+
+describe("EDFReader.readSamples", () => {
+  const nRecords = 3;
+  const nSamps = [10, 10, 5];
+  let ranges: [number, number][];
+  beforeEach(() => {
+    ranges = serve(buildEdf({ nRecords, nSamps }));
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("parses the header", async () => {
+    const r = await EDFReader.fromURL("http://x/f.edf");
+    expect(r.getNSignals()).toBe(3);
+    expect(Array.from(r.getNSamples())).toEqual([30, 30, 15]);
+    expect(Array.from(r.getSignalFreqs())).toEqual([10, 10, 5]);
+    expect(r.getSignalTextLabels()).toEqual(["ch0", "ch1", "ch2"]);
+  });
+
+  it("reads a half-open sample range across records with calibration applied", async () => {
+    const r = await EDFReader.fromURL("http://x/f.edf");
+    const x = await r.readSamples(1, 8, 13);
+    expect(Array.from(x)).toEqual(
+      [8, 9, 10, 11, 12].map((i) => physicalValue(1, i)),
+    );
+  });
+
+  it("reads through the end of the recording without touching a record past the end", async () => {
+    const r = await EDFReader.fromURL("http://x/f.edf");
+    const x = await r.readSamples(0, 25, 30);
+    expectSamples(
+      x,
+      [25, 26, 27, 28, 29].map((i) => physicalValue(0, i)),
+    );
+    const fileLength = 256 + 256 * 3 + nRecords * 25 * 2;
+    for (const [start] of ranges) {
+      expect(start).toBeLessThan(fileLength);
+    }
+  });
+
+  it("clamps a range that runs past the end", async () => {
+    const r = await EDFReader.fromURL("http://x/f.edf");
+    const x = await r.readSamples(2, 12, 100);
+    expectSamples(
+      x,
+      [12, 13, 14].map((i) => physicalValue(2, i)),
+    );
+    expect((await r.readSamples(2, 15, 20)).length).toBe(0);
+  });
+
+  it("reads exactly one record for a range that ends on a record boundary", async () => {
+    const r = await EDFReader.fromURL("http://x/f.edf");
+    const readBlock = vi.spyOn(r, "readBlockForChannel");
+    const x = await r.readSamples(0, 0, 10);
+    expect(x.length).toBe(10);
+    expect(readBlock).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads a whole signal", async () => {
+    const r = await EDFReader.fromURL("http://x/f.edf");
+    const x = await r.readSignal(2);
+    expect(x.length).toBe(15);
+    expect(x[14]).toBeCloseTo(physicalValue(2, 14), 3);
+  });
+
+  it("serves concurrent reads of different channels without stalling", async () => {
+    const r = await EDFReader.fromURL("http://x/f.edf");
+    const results = await Promise.race([
+      Promise.all([
+        r.readSamples(0, 0, 30),
+        r.readSamples(1, 0, 30),
+        r.readSamples(2, 0, 15),
+        r.readSamples(0, 20, 30),
+      ]),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("concurrent reads stalled")), 5000),
+      ),
+    ]);
+    expect(results.map((x) => x.length)).toEqual([30, 30, 15, 10]);
+  });
+});

--- a/src/shared/EdfViewer/EDFReader.test.ts
+++ b/src/shared/EdfViewer/EDFReader.test.ts
@@ -121,7 +121,8 @@ describe("EDFReader.readSamples", () => {
   it("reads a half-open sample range across records with calibration applied", async () => {
     const r = await EDFReader.fromURL("http://x/f.edf");
     const x = await r.readSamples(1, 8, 13);
-    expect(Array.from(x)).toEqual(
+    expectSamples(
+      x,
       [8, 9, 10, 11, 12].map((i) => physicalValue(1, i)),
     );
   });

--- a/src/shared/EdfViewer/EDFReader.ts
+++ b/src/shared/EdfViewer/EDFReader.ts
@@ -62,9 +62,14 @@ class RemoteFile {
         break;
       }
     }
+    // The count is captured here because a concurrent call (another channel,
+    // or a new view while this one is still loading) may change the instance
+    // field while this call awaits; marking, fetching, caching and clearing
+    // must all agree, or a chunk can be left marked in progress forever.
+    const numChunksToLoad = this.#smartLoadNumChunksToLoad;
     while (true) {
       let somethingInProgress = false;
-      for (let i = 0; i < this.#smartLoadNumChunksToLoad; i++) {
+      for (let i = 0; i < numChunksToLoad; i++) {
         if (this.#inProgressChunks[chunkIndex + i]) {
           somethingInProgress = true;
         }
@@ -74,19 +79,23 @@ class RemoteFile {
       }
       await new Promise((resolve) => setTimeout(resolve, 100));
     }
-    for (let i = 0; i < this.#smartLoadNumChunksToLoad; i++) {
+    if (this.#blockCache[chunkIndex]) {
+      // loaded by another call while we were waiting
+      return this.#blockCache[chunkIndex];
+    }
+    for (let i = 0; i < numChunksToLoad; i++) {
       if (!this.#blockCache[chunkIndex + i]) {
         this.#inProgressChunks[chunkIndex + i] = true;
       }
     }
     try {
       const offset = chunkIndex * this.#chunkSizeBytes;
-      const length = this.#chunkSizeBytes * this.#smartLoadNumChunksToLoad;
+      const length = this.#chunkSizeBytes * numChunksToLoad;
       const buf = await this._readBytes(offset, length);
       // now update the cache
       for (
         let chunkIndex2 = chunkIndex;
-        chunkIndex2 < chunkIndex + this.#smartLoadNumChunksToLoad;
+        chunkIndex2 < chunkIndex + numChunksToLoad;
         chunkIndex2++
       ) {
         const offset2 = (chunkIndex2 - chunkIndex) * this.#chunkSizeBytes;
@@ -98,7 +107,7 @@ class RemoteFile {
       }
       return buf.slice(0, this.#chunkSizeBytes);
     } finally {
-      for (let i = 0; i < this.#smartLoadNumChunksToLoad; i++) {
+      for (let i = 0; i < numChunksToLoad; i++) {
         this.#inProgressChunks[chunkIndex + i] = false;
       }
     }
@@ -394,6 +403,11 @@ class EDFReader {
     if (meas_info === null || chan_info === null) {
       throw new Error("No meas_info or chan_info has been read");
     }
+    if (block >= meas_info["n_records"]) {
+      throw new Error(
+        `Block ${block} is past the end of the file (${meas_info["n_records"]} records)`,
+      );
+    }
     if (this.#offset === null || this.#calibrate === null) {
       throw new Error("No offset or calibrate has been calculated");
     }
@@ -462,6 +476,10 @@ class EDFReader {
     return raw;
   }
 
+  // Samples [begsample, endsample) of a channel, in physical units. The end
+  // is exclusive, like Array.slice; it is clamped to the length of the
+  // signal, so a request that runs to the end of the recording reads only
+  // the records that exist.
   async readSamples(
     channel: number,
     begsample: number,
@@ -476,8 +494,12 @@ class EDFReader {
       throw new Error("No chan_info or meas_info has been read");
     }
     const n_samps = chan_info["n_samps"][channel];
-    const begblock = Math.floor(begsample / n_samps);
-    const endblock = Math.floor(endsample / n_samps);
+    const totalSamples = n_samps * meas_info["n_records"];
+    const beg = Math.max(0, begsample);
+    const end = Math.min(endsample, totalSamples);
+    if (end <= beg) return new Float32Array(0);
+    const begblock = Math.floor(beg / n_samps);
+    const endblock = Math.floor((end - 1) / n_samps);
 
     const data_blocks: Float32Array[] = [];
     for (let block = begblock; block <= endblock; block++) {
@@ -486,10 +508,7 @@ class EDFReader {
     }
     const data = concatFloat32Arrays(data_blocks);
 
-    begsample -= begblock * n_samps;
-    endsample -= begblock * n_samps;
-
-    return data.slice(begsample, endsample + 1);
+    return data.slice(beg - begblock * n_samps, end - begblock * n_samps);
   }
 
   getSignalTextLabels(): string[] {
@@ -538,7 +557,7 @@ class EDFReader {
     }
     const begsample = 0;
     const endsample =
-      this.#chan_info["n_samps"][chanindx] * this.#meas_info["n_records"] - 1;
+      this.#chan_info["n_samps"][chanindx] * this.#meas_info["n_records"];
     return await this.readSamples(chanindx, begsample, endsample);
   }
 

--- a/src/shared/EdfViewer/EdfViewer.tsx
+++ b/src/shared/EdfViewer/EdfViewer.tsx
@@ -2,6 +2,7 @@ import { Splitter } from "@fi-sci/splitter";
 import { TimeseriesTimestampsClient } from "@shared/TimeseriesTimestampsClient/TimeseriesTimestampsClient";
 import { FunctionComponent, useEffect, useMemo, useState } from "react";
 import EDFReader from "./EDFReader";
+import { channelStdev, computeMedian } from "./edfStats";
 import {
   DatasetChunkingClientInterface,
   NwbTimeseriesViewChild,
@@ -464,7 +465,7 @@ const useDatasetChunkingClientForEdfReader = (
               "Skipping channel because it has a different sampling rate than the first channel: " +
                 iChannel,
             );
-            break;
+            continue;
           }
           const xx = await edfReader.readSamples(iChannel, jj1, jj2);
           for (let j = 0; j < xx.length; j++) {
@@ -501,14 +502,7 @@ const useDatasetChunkingClientForEdfReader = (
         { onCancel: [] },
       );
       const concatenatedChunk = initialChunk.concatenatedChunk;
-      const channelStdevs = concatenatedChunk.map((x) => {
-        if (!x.length) return 0;
-        const sum = x.reduce((a, b) => a + b, 0);
-        const mean = sum / x.length;
-        const sum2 = x.reduce((a, b) => a + (b - mean) ** 2, 0);
-        return Math.sqrt(sum2 / x.length);
-      });
-      setEstimatedChannelStdevs(channelStdevs);
+      setEstimatedChannelStdevs(concatenatedChunk.map(channelStdev));
     })();
   }, [datasetChunkingClient]);
   const datasetChunkingClient2 = useMemo(() => {
@@ -603,15 +597,6 @@ const useOpenNeuroInfo = (url: string): OpenNeuroEDFInfo | null => {
     }
   }
   return null;
-};
-
-const computeMedian = (x: number[]) => {
-  if (x.length === 0) return 0;
-  const y = x.slice().sort((a, b) => a - b);
-  if (y.length % 2 === 1) {
-    return y[Math.floor(y.length / 2)];
-  }
-  return (y[y.length / 2 - 1] + y[y.length / 2]) / 2;
 };
 
 export default EdfViewer;

--- a/src/shared/EdfViewer/edfStats.test.ts
+++ b/src/shared/EdfViewer/edfStats.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { channelStdev, computeMedian } from "./edfStats";
+
+describe("channelStdev", () => {
+  it("computes the population standard deviation", () => {
+    expect(channelStdev([2, 4, 4, 4, 5, 5, 7, 9])).toBeCloseTo(2);
+  });
+  it("ignores NaN samples", () => {
+    expect(channelStdev([2, NaN, 4, 4, 4, 5, 5, 7, 9, NaN])).toBeCloseTo(2);
+  });
+  it("is NaN for a channel with no loaded samples", () => {
+    expect(channelStdev([NaN, NaN])).toBeNaN();
+    expect(channelStdev([])).toBeNaN();
+  });
+});
+
+describe("computeMedian", () => {
+  it("handles odd and even counts", () => {
+    expect(computeMedian([3, 1, 2])).toBe(2);
+    expect(computeMedian([4, 1, 3, 2])).toBe(2.5);
+  });
+  it("leaves out NaN entries so one skipped channel does not blank the rest", () => {
+    expect(computeMedian([1, NaN, 3])).toBe(2);
+    expect(computeMedian([NaN])).toBe(0);
+    expect(computeMedian([])).toBe(0);
+  });
+});

--- a/src/shared/EdfViewer/edfStats.ts
+++ b/src/shared/EdfViewer/edfStats.ts
@@ -1,0 +1,31 @@
+// Statistics used to scale channel separation. Samples that could not be
+// loaded are NaN (a channel with a different sampling rate, or a load that
+// was cut short), and one NaN would otherwise poison the separation of
+// every channel, so NaN samples and NaN channels are left out.
+
+export const channelStdev = (x: ArrayLike<number>): number => {
+  let n = 0;
+  let sum = 0;
+  for (let i = 0; i < x.length; i++) {
+    if (isNaN(x[i])) continue;
+    n++;
+    sum += x[i];
+  }
+  if (n === 0) return NaN;
+  const mean = sum / n;
+  let sum2 = 0;
+  for (let i = 0; i < x.length; i++) {
+    if (isNaN(x[i])) continue;
+    sum2 += (x[i] - mean) ** 2;
+  }
+  return Math.sqrt(sum2 / n);
+};
+
+export const computeMedian = (x: number[]): number => {
+  const y = x.filter((v) => !isNaN(v)).sort((a, b) => a - b);
+  if (y.length === 0) return 0;
+  if (y.length % 2 === 1) {
+    return y[Math.floor(y.length / 2)];
+  }
+  return (y[y.length / 2 - 1] + y[y.length / 2]) / 2;
+};


### PR DESCRIPTION
Fixes #480.

`EDFReader.readSamples` treated its end argument as inclusive while `EdfViewer` passes an exclusive index. Reaching the end of a recording therefore requested a record past the end of the file, the read threw, and the view stayed on "Loading timeseries data...". A window ending exactly on a record boundary also read one record too many.

`readSamples` is now a half-open range, clamped to the signal, so it reads only the records that exist, and `readBlockForChannel` refuses a record index past the end with a clear error. `readSignal` is adjusted for the new convention. In `RemoteFile.readChunkWithSmartLoad` the number of chunks to load is captured once per call; previously a concurrent call could halve the instance field mid-flight so that chunks marked in progress were never cleared and later reads of them waited forever. A chunk that finished loading while a call was waiting is now returned from the cache rather than fetched again.

In the viewer, a channel with a different sampling rate is skipped with `continue` instead of `break`, so only that channel is left as NaN. The standard deviation and median used for channel separation move to `edfStats.ts` and ignore NaN, so a skipped channel no longer turns the separation into NaN and blanks every trace.

Tests: `EDFReader.test.ts` builds a three-channel EDF file in memory with a known value at every (channel, index), serves it through a stubbed `fetch` that honors Range headers, and checks header parsing, calibrated reads across records, a read through the end of the recording that never requests bytes past the file, clamping of an over-long range, a single record read for a boundary-aligned range, a whole-signal read, and concurrent reads of several channels completing. Five of the seven fail on the previous reader. `edfStats.test.ts` covers the NaN handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c