### PR TITLE
Encode the dandiset search text in the API request

### DIFF
--- a/src/pages/DandiPage/DandiPage.tsx
+++ b/src/pages/DandiPage/DandiPage.tsx
@@ -1,3 +1,4 @@
+import { buildDandisetsSearchUrl } from "../util/dandisetsSearchUrl";
 import ScrollY from "@components/ScrollY";
 import HistoryIcon from "@mui/icons-material/History";
 import LaunchIcon from "@mui/icons-material/Launch";
@@ -110,12 +111,14 @@ const DandiPage: FunctionComponent<DandiPageProps> = ({ width, height }) => {
           searchResultDandisetIds = await doDandiSemanticSearch(searchQuery);
         } else if (searchMode === "basic") {
           const { headers, apiKeyProvided } = getDandiApiHeaders(staging);
-          const embargoedStr = apiKeyProvided ? "true" : "false";
           const stagingStr = staging ? ".sandbox" : "";
-          const emptyStr = !searchQuery ? "false" : "true";
 
           const response = await fetch(
-            `https://api${stagingStr}.dandiarchive.org/api/dandisets/?page=1&page_size=50&ordering=-modified&search=${searchQuery}&draft=true&empty=${emptyStr}&embargoed=${embargoedStr}`,
+            buildDandisetsSearchUrl({
+              apiBaseUrl: `https://api${stagingStr}.dandiarchive.org`,
+              searchQuery,
+              embargoed: apiKeyProvided,
+            }),
             { headers },
           );
           if (response.status === 200) {

--- a/src/pages/EmberPage/EmberDandiPage.tsx
+++ b/src/pages/EmberPage/EmberDandiPage.tsx
@@ -1,3 +1,4 @@
+import { buildDandisetsSearchUrl } from "../util/dandisetsSearchUrl";
 import ScrollY from "@components/ScrollY";
 import HistoryIcon from "@mui/icons-material/History";
 import LaunchIcon from "@mui/icons-material/Launch";
@@ -96,13 +97,14 @@ const EmberDandiPage: FunctionComponent<DandiPageProps> = ({
     try {
       if (searchMode === "basic") {
         const { headers, apiKeyProvided } = getEmberApiHeaders();
-        const embargoedStr = apiKeyProvided ? "true" : "false";
-        // const stagingStr = staging ? "-staging" : "";
-        const emptyStr = !searchQuery ? "false" : "true";
 
         // TODO - should we support sandbox at all? Doesn't seem to be working as well there
         const response = await fetch(
-          `https://api-dandi.emberarchive.org/api/dandisets/?page=1&page_size=50&ordering=-modified&search=${searchQuery}&draft=true&empty=${emptyStr}&embargoed=${embargoedStr}`,
+          buildDandisetsSearchUrl({
+            apiBaseUrl: "https://api-dandi.emberarchive.org",
+            searchQuery,
+            embargoed: apiKeyProvided,
+          }),
           { headers },
         );
         if (response.status === 200) {

--- a/src/pages/util/dandisetsSearchUrl.test.ts
+++ b/src/pages/util/dandisetsSearchUrl.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { buildDandisetsSearchUrl } from "./dandisetsSearchUrl";
+
+describe("buildDandisetsSearchUrl", () => {
+  it("encodes characters that would otherwise break the query string", () => {
+    const url = buildDandisetsSearchUrl({
+      apiBaseUrl: "https://api.dandiarchive.org",
+      searchQuery: "cortex & hippocampus #2 C++",
+      embargoed: false,
+    });
+    const parsed = new URL(url);
+    expect(parsed.origin + parsed.pathname).toBe(
+      "https://api.dandiarchive.org/api/dandisets/",
+    );
+    expect(parsed.searchParams.get("search")).toBe(
+      "cortex & hippocampus #2 C++",
+    );
+    expect(parsed.searchParams.get("empty")).toBe("true");
+    expect(parsed.searchParams.get("embargoed")).toBe("false");
+    expect(parsed.searchParams.get("page_size")).toBe("50");
+    expect(parsed.searchParams.get("ordering")).toBe("-modified");
+    expect(parsed.searchParams.get("draft")).toBe("true");
+  });
+
+  it("hides empty dandisets when there is no search text", () => {
+    const url = buildDandisetsSearchUrl({
+      apiBaseUrl: "https://api.sandbox.dandiarchive.org",
+      searchQuery: "",
+      embargoed: true,
+    });
+    const parsed = new URL(url);
+    expect(parsed.host).toBe("api.sandbox.dandiarchive.org");
+    expect(parsed.searchParams.get("search")).toBe("");
+    expect(parsed.searchParams.get("empty")).toBe("false");
+    expect(parsed.searchParams.get("embargoed")).toBe("true");
+  });
+});

--- a/src/pages/util/dandisetsSearchUrl.ts
+++ b/src/pages/util/dandisetsSearchUrl.ts
@@ -1,0 +1,21 @@
+// The DANDI archive API (and EMBER's DANDI-compatible API) list endpoint
+// for dandisets, with the free-text search encoded so that characters such
+// as "&", "#", "+" and spaces reach the server intact.
+export const buildDandisetsSearchUrl = (o: {
+  apiBaseUrl: string; // e.g. https://api.dandiarchive.org
+  searchQuery: string;
+  embargoed: boolean;
+  pageSize?: number;
+}): string => {
+  const params = new URLSearchParams({
+    page: "1",
+    page_size: String(o.pageSize ?? 50),
+    ordering: "-modified",
+    search: o.searchQuery,
+    draft: "true",
+    // an empty search lists everything, so hide empty dandisets then
+    empty: o.searchQuery ? "true" : "false",
+    embargoed: o.embargoed ? "true" : "false",
+  });
+  return `${o.apiBaseUrl}/api/dandisets/?${params.toString()}`;
+};


### PR DESCRIPTION
Fixes #484.

The DANDI and EMBER search pages interpolated the search text straight into the request URL. An ampersand started a new parameter, a hash truncated the URL, and a plus became a space, so such queries returned the wrong results without any error.

Both pages now call `buildDandisetsSearchUrl` in `src/pages/util/dandisetsSearchUrl.ts`, which assembles the same parameters with `URLSearchParams`. The empty-dandiset and embargoed flags keep their previous meaning. Tests parse the produced URL and check that a query with those characters survives, and that an empty query hides empty dandisets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c