### PR TITLE
Follow every page of a dandiset directory listing

### DIFF
--- a/src/pages/DandisetPage/hooks/useLazyDandisetPaths.ts
+++ b/src/pages/DandisetPage/hooks/useLazyDandisetPaths.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import getAuthorizationHeaderForUrl from "../../util/getAuthorizationHeaderForUrl";
 import { DatasetFile } from "../../common/DatasetWorkspace/plugins/pluginInterface";
 import { DandisetVersionInfo } from "../../DandiPage/dandi-types";
+import { fetchAllPages } from "../../util/fetchAllPages";
 
 // Cache for storing loaded directories
 interface CachedDirectory {
@@ -96,11 +97,12 @@ export const useLazyDandisetPaths = (
       const url = `${baseUrl}/${dandisetId}/versions/${dandisetVersionInfo.version}/assets/paths/?page=1&page_size=1000&path_prefix=${encodedPrefix}${globFilter}`;
 
       try {
-        const response = await fetch(url, { headers });
-        if (!response.ok) throw new Error("Failed to fetch directory contents");
-
-        const data: DandiPathResponse = await response.json();
-        return data.results;
+        // Follow every page: a directory can hold more entries than one
+        // page of the listing.
+        return await fetchAllPages<DandiPathResponse["results"][0]>(
+          url,
+          headers,
+        );
       } catch (err) {
         console.error("Error fetching directory:", err);
         return [];

--- a/src/pages/EmberDandisetPage/hooks/useLazyDandisetPaths.ts
+++ b/src/pages/EmberDandisetPage/hooks/useLazyDandisetPaths.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import getAuthorizationHeaderForUrl from "../../util/getAuthorizationHeaderForUrl";
 import { DatasetFile } from "../../common/DatasetWorkspace/plugins/pluginInterface";
 import { DandisetVersionInfo } from "../../DandiPage/dandi-types";
+import { fetchAllPages } from "../../util/fetchAllPages";
 
 // Cache for storing loaded directories
 interface CachedDirectory {
@@ -96,11 +97,12 @@ export const useLazyDandisetPaths = (
       const url = `${baseUrl}/${dandisetId}/versions/${dandisetVersionInfo.version}/assets/paths/?page=1&page_size=1000&path_prefix=${encodedPrefix}${globFilter}`;
 
       try {
-        const response = await fetch(url, { headers });
-        if (!response.ok) throw new Error("Failed to fetch directory contents");
-
-        const data: DandiPathResponse = await response.json();
-        return data.results;
+        // Follow every page: a directory can hold more entries than one
+        // page of the listing.
+        return await fetchAllPages<DandiPathResponse["results"][0]>(
+          url,
+          headers,
+        );
       } catch (err) {
         console.error("Error fetching directory:", err);
         return [];

--- a/src/pages/util/fetchAllPages.test.ts
+++ b/src/pages/util/fetchAllPages.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchAllPages } from "./fetchAllPages";
+
+const pages: { [url: string]: { results: number[]; next: string | null } } = {
+  "https://api.example/paths/?page=1": {
+    results: [1, 2, 3],
+    next: "https://api.example/paths/?page=2",
+  },
+  "https://api.example/paths/?page=2": {
+    results: [4, 5],
+    next: "https://api.example/paths/?page=3",
+  },
+  "https://api.example/paths/?page=3": { results: [6], next: null },
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("fetchAllPages", () => {
+  it("follows next links and concatenates the results in order", async () => {
+    const requested: string[] = [];
+    const seenHeaders: unknown[] = [];
+    vi.stubGlobal("fetch", async (url: string, init: { headers?: unknown }) => {
+      requested.push(url);
+      seenHeaders.push(init.headers);
+      const page = pages[url];
+      return { ok: true, status: 200, json: async () => page };
+    });
+    const out = await fetchAllPages<number>(
+      "https://api.example/paths/?page=1",
+      { Authorization: "token x" },
+    );
+    expect(out).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(requested).toEqual(Object.keys(pages));
+    expect(
+      seenHeaders.every(
+        (h) => (h as { Authorization: string }).Authorization === "token x",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns a single page when there is no next link", async () => {
+    vi.stubGlobal("fetch", async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ results: ["a"], next: undefined }),
+    }));
+    expect(await fetchAllPages<string>("https://api.example/one")).toEqual([
+      "a",
+    ]);
+  });
+
+  it("throws when a page request fails", async () => {
+    vi.stubGlobal("fetch", async () => ({ ok: false, status: 403 }));
+    await expect(fetchAllPages("https://api.example/x")).rejects.toThrow(/403/);
+  });
+});

--- a/src/pages/util/fetchAllPages.ts
+++ b/src/pages/util/fetchAllPages.ts
@@ -1,0 +1,33 @@
+// Collect every result of a paginated DANDI API listing. The API returns
+// at most a page of results at a time and points to the rest with `next`,
+// so a listing that stops at the first page silently loses everything past
+// it (a directory with more than a thousand files, for example).
+export type PaginatedResponse<T> = {
+  results: T[];
+  next?: string | null;
+};
+
+// The page count is bounded so that a misbehaving server cannot keep a
+// client looping; a directory of this many pages is not a realistic case.
+export const MAX_PAGES = 200;
+
+export const fetchAllPages = async <T>(
+  firstUrl: string,
+  headers?: { [key: string]: string },
+): Promise<T[]> => {
+  const results: T[] = [];
+  let url: string | null | undefined = firstUrl;
+  for (let page = 0; url && page < MAX_PAGES; page++) {
+    const response = await fetch(url, { headers });
+    if (!response.ok) {
+      throw new Error(`Request failed (${response.status}) for ${url}`);
+    }
+    const data = (await response.json()) as PaginatedResponse<T>;
+    results.push(...data.results);
+    url = data.next;
+  }
+  if (url) {
+    console.warn(`Stopped following pages after ${MAX_PAGES}: ${url}`);
+  }
+  return results;
+};


### PR DESCRIPTION
Fixes #486.

`fetchDirectoryContents` in both copies of `useLazyDandisetPaths` returned the results of the first page of the `assets/paths` listing, so a directory with more than a thousand entries lost the rest without any sign of it.

The listing now goes through `fetchAllPages` in `src/pages/util/fetchAllPages.ts`, which follows `next` until it is null, forwards the same headers to every page, throws on a failed page (the hooks keep their existing catch that logs and returns an empty listing), and stops after a large bound of pages with a warning. Tests stub `fetch` and check that three pages are concatenated in order with the headers forwarded, that a single page works, and that a failed page rejects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c