### PR TITLE
Fall back to the HDF5 file when the LINDI index is unreachable

### DIFF
--- a/src/pages/NwbPage/hdf5Interface.ts
+++ b/src/pages/NwbPage/hdf5Interface.ts
@@ -559,7 +559,14 @@ export const tryGetLindiUrl = async (url: string, dandisetId: string) => {
   if (!assetId) return undefined;
   const aa = staging ? "dandi-staging" : "dandi";
   const tryUrl = `https://lindi.neurosift.org/${aa}/dandisets/${dandisetId}/assets/${assetId}/nwb.lindi.json`;
-  const resp = await fetch(tryUrl, { method: "HEAD" });
-  if (resp.ok) return tryUrl;
+  // The LINDI index is an optimization. If it cannot be reached (network
+  // error, CORS failure, outage), fall back to the HDF5 file itself rather
+  // than failing the whole load.
+  try {
+    const resp = await fetch(tryUrl, { method: "HEAD" });
+    if (resp.ok) return tryUrl;
+  } catch (err) {
+    console.warn(`Unable to check for a LINDI file at ${tryUrl}:`, err);
+  }
   return undefined;
 };

--- a/src/pages/NwbPage/tryGetLindiUrl.test.ts
+++ b/src/pages/NwbPage/tryGetLindiUrl.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// The module graph reaches the worker-backed HDF5 reader, which creates a
+// worker at import time, so stub that out for node.
+vi.stubGlobal(
+  "Worker",
+  class {
+    postMessage() {}
+    addEventListener() {}
+    removeEventListener() {}
+    terminate() {}
+  },
+);
+if (typeof URL.createObjectURL !== "function") {
+  URL.createObjectURL = () => "blob:stub";
+}
+vi.mock("./hdf5Cache", () => ({
+  getCachedObject: async () => undefined,
+  setCachedObject: async () => {},
+}));
+vi.mock("@components/StatusBarContext", () => ({
+  setStatusItem: () => {},
+  removeStatusItem: () => {},
+}));
+
+const { tryGetLindiUrl } = await import("./hdf5Interface");
+
+const assetUrl = "https://api.dandiarchive.org/api/assets/0123-4567/download/";
+const expectedLindiUrl =
+  "https://lindi.neurosift.org/dandi/dandisets/000001/assets/0123-4567/nwb.lindi.json";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("tryGetLindiUrl", () => {
+  it("returns the LINDI url when the index answers ok", async () => {
+    const calls: [string, RequestInit | undefined][] = [];
+    vi.stubGlobal("fetch", async (url: string, init?: RequestInit) => {
+      calls.push([url, init]);
+      return { ok: true };
+    });
+    expect(await tryGetLindiUrl(assetUrl, "000001")).toBe(expectedLindiUrl);
+    expect(calls).toEqual([[expectedLindiUrl, { method: "HEAD" }]]);
+  });
+
+  it("returns undefined when the index has no file", async () => {
+    vi.stubGlobal("fetch", async () => ({ ok: false, status: 404 }));
+    expect(await tryGetLindiUrl(assetUrl, "000001")).toBeUndefined();
+  });
+
+  it("returns undefined instead of throwing when the index is unreachable", async () => {
+    vi.stubGlobal("fetch", async () => {
+      throw new TypeError("Failed to fetch");
+    });
+    await expect(tryGetLindiUrl(assetUrl, "000001")).resolves.toBeUndefined();
+  });
+
+  it("passes a lindi url through and ignores non-DANDI urls", async () => {
+    vi.stubGlobal("fetch", async () => {
+      throw new Error("should not be called");
+    });
+    expect(await tryGetLindiUrl("https://x/y.lindi.json", "000001")).toBe(
+      "https://x/y.lindi.json",
+    );
+    expect(
+      await tryGetLindiUrl("https://example.org/file.nwb", "000001"),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #488.

The HEAD request in `tryGetLindiUrl` that checks `lindi.neurosift.org` for a LINDI version of a DANDI asset was not guarded. If that host was unreachable the rejection propagated through `getResolvedUrl` and the asset failed to load, even though the HDF5 URL itself was fine. The lookup now catches the error, warns, and returns `undefined`, so the reader falls back to the HDF5 file as it does when no LINDI file exists.

Tests in `tryGetLindiUrl.test.ts` stub `fetch` and cover a positive answer (with the exact index URL and HEAD method), a 404, a thrown network error, a `.lindi.json` URL passed through untouched, and a non-DANDI URL. The unreachable case fails on the previous code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c