### PR TITLE
Size the qfc int16 output by sample count

### DIFF
--- a/src/remote-h5-file/lib/lindi/qfc.test.ts
+++ b/src/remote-h5-file/lib/lindi/qfc.test.ts
@@ -1,0 +1,83 @@
+import pako from "pako";
+import { describe, expect, it } from "vitest";
+import { qfcDecompress } from "./qfc";
+
+// A qfc chunk is a 5-int32 header followed by zlib-compressed int16
+// quantized spectral coefficients, num_samples * num_channels of them per
+// segment. All-zero coefficients decode to an all-zero signal, which is
+// enough to check the output type and length for each dtype and path.
+const buildChunk = (o: {
+  numSamples: number;
+  numChannels: number;
+  segmentLength: number;
+}) => {
+  const header = new Int32Array([
+    7364182,
+    1,
+    o.numSamples,
+    o.numChannels,
+    o.segmentLength,
+  ]);
+  const coefficients = new Int16Array(o.numSamples * o.numChannels);
+  const compressed = pako.deflate(new Uint8Array(coefficients.buffer));
+  const out = new Uint8Array(header.byteLength + compressed.byteLength);
+  out.set(new Uint8Array(header.buffer), 0);
+  out.set(compressed, header.byteLength);
+  return out.buffer;
+};
+
+const compressor = (dtype: "int16" | "float32", segmentLength: number) => ({
+  id: "qfc" as const,
+  compression_method: "zlib" as const,
+  dtype,
+  quant_scale_factor: 0.01,
+  segment_length: segmentLength,
+  zlib_level: 3,
+  zstd_level: 3,
+});
+
+describe("qfcDecompress", () => {
+  it("decodes an unsegmented int16 chunk to one value per sample", async () => {
+    const shape = [8, 2];
+    const out = await qfcDecompress(
+      buildChunk({ numSamples: 8, numChannels: 2, segmentLength: 0 }),
+      shape,
+      compressor("int16", 0),
+    );
+    expect(out.byteLength).toBe(8 * 2 * 2);
+    expect(Array.from(new Int16Array(out.buffer ?? out))).toEqual(
+      new Array(16).fill(0),
+    );
+  });
+
+  it("decodes a segmented int16 chunk", async () => {
+    const out = await qfcDecompress(
+      buildChunk({ numSamples: 8, numChannels: 1, segmentLength: 4 }),
+      [8, 1],
+      compressor("int16", 4),
+    );
+    expect(out.byteLength).toBe(8 * 2);
+  });
+
+  it("decodes a float32 chunk to one value per sample", async () => {
+    const out = await qfcDecompress(
+      buildChunk({ numSamples: 8, numChannels: 2, segmentLength: 0 }),
+      [8, 2],
+      compressor("float32", 0),
+    );
+    expect(out.byteLength).toBe(8 * 2 * 4);
+    expect(Array.from(new Float32Array(out.buffer ?? out))).toEqual(
+      new Array(16).fill(0),
+    );
+  });
+
+  it("rejects a chunk whose header disagrees with the shape", async () => {
+    await expect(
+      qfcDecompress(
+        buildChunk({ numSamples: 8, numChannels: 2, segmentLength: 0 }),
+        [9, 2],
+        compressor("int16", 0),
+      ),
+    ).rejects.toThrow(/num samples/);
+  });
+});

--- a/src/remote-h5-file/lib/lindi/qfc.ts
+++ b/src/remote-h5-file/lib/lindi/qfc.ts
@@ -242,7 +242,9 @@ const qfc_inv_pre_compress = async (o: {
     x_fft[i] = x_fft[i] * Math.sqrt(num_samples);
   }
   if (dtype === "int16") {
-    const ret = new Int16Array(x_fft.byteLength);
+    // One int16 per sample: sizing this by byteLength allocated four times
+    // too many elements and made every int16 decode fail its length check.
+    const ret = new Int16Array(x_fft.length);
     for (let i = 0; i < x_fft.length; i++) {
       ret[i] = Math.round(x_fft[i]);
     }


### PR DESCRIPTION
Fixes #490.

`qfc_inv_pre_compress` allocated its int16 result as `new Int16Array(x_fft.byteLength)`, four times the number of samples, so the decompressed buffer never matched the expected length and `qfcDecompress` threw for every int16 dataset. The allocation now uses `x_fft.length`.

Tests in `qfc.test.ts` build synthetic chunks (the 5-int32 header followed by zlib-compressed zero coefficients) and check the decoded byte length and values for an unsegmented int16 chunk, a segmented int16 chunk, and a float32 chunk, and that a shape mismatch is rejected. The two int16 cases fail on the previous code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c