### PR TITLE
Fix the qfc test type error and run PR checks on Node 22

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -25,7 +25,9 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        # vitest 4 needs Node 20 or later and jsdom 30 needs 22.22 or later;
+        # Node 18 cannot require() the ESM-only modules jsdom depends on.
+        node-version: '22'
         cache: 'npm'
 
     # Install Python dependencies

--- a/src/remote-h5-file/lib/lindi/qfc.test.ts
+++ b/src/remote-h5-file/lib/lindi/qfc.test.ts
@@ -45,9 +45,7 @@ describe("qfcDecompress", () => {
       compressor("int16", 0),
     );
     expect(out.byteLength).toBe(8 * 2 * 2);
-    expect(Array.from(new Int16Array(out.buffer ?? out))).toEqual(
-      new Array(16).fill(0),
-    );
+    expect(Array.from(new Int16Array(out))).toEqual(new Array(16).fill(0));
   });
 
   it("decodes a segmented int16 chunk", async () => {
@@ -66,9 +64,7 @@ describe("qfcDecompress", () => {
       compressor("float32", 0),
     );
     expect(out.byteLength).toBe(8 * 2 * 4);
-    expect(Array.from(new Float32Array(out.buffer ?? out))).toEqual(
-      new Array(16).fill(0),
-    );
+    expect(Array.from(new Float32Array(out))).toEqual(new Array(16).fill(0));
   });
 
   it("rejects a chunk whose header disagrees with the shape", async () => {


### PR DESCRIPTION
Two things currently make `main` fail its PR checks; both are needed for any PR to go green, so they are in one PR.

The test added in #491 read `out.buffer ?? out` while `qfcDecompress` still returned `any`; #499 then typed the return as `ArrayBuffer`. Each PR passed on its own, but together the property access does not type-check and `tsc -b` fails. The test now passes the buffer straight to the typed array constructors.

Since #499 the checks also run `npm test`, and since #469 the suite has jsdom tests. On the Node 18 runner those fail with `ERR_REQUIRE_ESM`: jsdom's `html-encoding-sniffer` depends on `@exodus/bytes`, which is ESM-only, and Node 18 cannot `require()` ES modules. jsdom 30 supports Node 22.22 and later and vitest 4 needs Node 20 or later, so the runner is now Node 22. Locally the full suite passes on Node 22.23; on Node 20.19 the jsdom test files fail to start with `TypeError: webidl.util.markAsUncloneable is not a function`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c