### PR TITLE
Run PR checks on Node 22

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -25,7 +25,9 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        # vitest 4 needs Node 20 or later and jsdom 30 needs 22.22 or later;
+        # Node 18 cannot require() the ESM-only modules jsdom depends on.
+        node-version: '22'
         cache: 'npm'
 
     # Install Python dependencies


### PR DESCRIPTION
Since #499 the PR checks run `npm test`, and since #469 the suite includes jsdom tests. On the Node 18 runner those fail with `ERR_REQUIRE_ESM`: jsdom's `html-encoding-sniffer` depends on `@exodus/bytes`, which is ESM-only, and Node 18 cannot `require()` ES modules. jsdom 30 declares support for Node 22.22 and later, and vitest 4 needs Node 20 or later, so the runner is now Node 22.

Verified locally: the full suite passes on Node 22.23; on Node 20.19 the same jsdom test files fail to start their worker with `TypeError: webidl.util.markAsUncloneable is not a function` from jsdom's fetch layer. `main` is currently red on this step for the same reason, so this should merge alongside #508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c