### PR TITLE
Bump neurosift to 0.2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changes
 
+## September 4, 2026
+
+- Released neurosift 0.2.16 on PyPI. The local file server started by `neurosift view-nwb` no longer exits on a request for a forbidden path or a directory, handles byte ranges correctly (clamped ranges, suffix ranges, 416 for unsatisfiable ones), answers HEAD requests, and listens on localhost only. `view-nwb` refuses zarr directories with a clear message and installs the server's npm dependencies only once.
+
 ## August 13, 2026
 
 - Show a relative time axis instead of an empty plot when a TimeSeries has a NaN `starting_time`

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "neurosift"
-version = "0.2.15"
+version = "0.2.16"
 description = "Simple utility to view local NWB files using Neurosift"
 authors = [
     { name = "Jeremy Magland", email = "jmagland@flatironinstitute.org" },


### PR DESCRIPTION
Version bump and changelog entry for the PyPI release that carries the hardened local file server (#459) and the CLI changes (#505). The package was built locally from this commit: both artifacts pass `twine check`, the wheel contains the new `local-file-access-js/src/index.js` and nothing from `spec/` or `checks/`, and the CLI checks pass against the installed wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c