### PR TITLE
Add a workflow that publishes the neurosift package to PyPI on a tag

### DIFF
--- a/.github/workflows/publish-neurosift-package.yml
+++ b/.github/workflows/publish-neurosift-package.yml
@@ -1,0 +1,78 @@
+name: Publish neurosift package
+
+# Builds the neurosift Python package and publishes it to PyPI when a
+# version tag is pushed. Publishing uses PyPI trusted publishing (OpenID
+# Connect), so no API token is stored in the repository; the PyPI project
+# must list this workflow as a trusted publisher (see CONTRIBUTING.md).
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build the package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Check that the tag matches the package version
+        if: github.ref_type == 'tag'
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          version=$(python -c "import tomllib; print(tomllib.load(open('python/pyproject.toml','rb'))['project']['version'])")
+          if [ "$tag" != "$version" ]; then
+            echo "Tag v$tag does not match python/pyproject.toml version $version"
+            exit 1
+          fi
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build twine
+          cd python
+          python -m build
+          python -m twine check dist/*
+
+      - name: Check the wheel contents
+        run: |
+          python - <<'PY'
+          import glob, zipfile
+          wheel = glob.glob("python/dist/*.whl")[0]
+          names = zipfile.ZipFile(wheel).namelist()
+          assert any(n.endswith("local-file-access-js/src/index.js") for n in names), "file server missing from wheel"
+          assert not any("spec/" in n or "checks/" in n or "node_modules" in n for n in names), "unexpected files in wheel"
+          print("\n".join(names))
+          PY
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: neurosift-dist
+          path: python/dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/neurosift/
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: neurosift-dist
+          path: dist/
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,19 @@ npm test               # unit tests (vitest)
 
 The repository also has pre-commit hooks (formatting and codespell) that you can enable with `pre-commit install`.
 
+## Releasing the Python Package
+
+The `neurosift` package in `python/` is published to PyPI by the `Publish neurosift package` workflow when a version tag is pushed. To cut a release:
+
+1. Bump `version` in `python/pyproject.toml` and add a `CHANGELOG.md` entry, and merge that to `main`.
+2. Tag the merge commit and push the tag:
+
+   ```bash
+   git tag v0.2.16 main && git push origin v0.2.16
+   ```
+
+The workflow builds the sdist and wheel, checks that the tag matches the version in `pyproject.toml`, checks the wheel contents, and publishes through PyPI trusted publishing. The PyPI project must list this repository's `publish-neurosift-package.yml` workflow and the `pypi` GitHub environment as a trusted publisher (PyPI project page, "Publishing" tab); no API token is stored in GitHub.
+
 ## Pull Requests
 
 - Update `CHANGELOG.md` with a brief entry describing your change.


### PR DESCRIPTION
Releases of the `neurosift` Python package have been manual `twine` uploads from a laptop, and the repository tags stopped at 0.2.8 while PyPI is at 0.2.15.

`publish-neurosift-package.yml` runs on a push of a `vX.Y.Z` tag (and on manual dispatch, which builds but does not publish). The build job checks that the tag matches `python/pyproject.toml`, builds the sdist and wheel, runs `twine check`, and verifies that the wheel contains `local-file-access-js/src/index.js` and nothing from `spec/`, `checks/`, or `node_modules`. The publish job then uploads through PyPI trusted publishing from a `pypi` GitHub environment with `id-token: write`, so no API token is stored in GitHub.

One-time setup, which needs the PyPI project owner: on https://pypi.org/manage/project/neurosift/settings/publishing/ add a trusted publisher with owner `flatironinstitute`, repository `neurosift`, workflow `publish-neurosift-package.yml`, environment `pypi`. Optionally create the `pypi` environment under the repository settings with required reviewers, which makes every publish wait for an approval click. `CONTRIBUTING.md` gains a section with the release steps.

After this merges, pushing `v0.2.16` on `main` publishes the release that #510 prepared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c