### PR TITLE
Clamp TwoPhotonSeries frame stepping to the dataset

### DIFF
--- a/src/pages/NwbPage/plugins/TwoPhotonSeries/TwoPhotonSeriesItemView/TwoPhotonSeriesItemView.tsx
+++ b/src/pages/NwbPage/plugins/TwoPhotonSeries/TwoPhotonSeriesItemView/TwoPhotonSeriesItemView.tsx
@@ -1,3 +1,4 @@
+import { canStepFrame, steppedFrameIndex } from "./frameStepping";
 import { SmallIconButton } from "@fi-sci/misc";
 import { ArrowLeft, ArrowRight } from "@mui/icons-material";
 import { getHdf5DatasetData, useHdf5Dataset } from "@hdf5Interface";
@@ -178,13 +179,14 @@ export const TwoPhotonSeriesItemView: FunctionComponent<Props> = ({
 
   const bottomBarHeight = 30;
 
+  const numFrames = dataDataset?.shape[0];
+
   const incrementFrame = useMemo(
     () => (inc: number) => {
       (async () => {
         if (!timeseriesTimestampsClient) return;
-        if (frameIndex === undefined) return;
-        const i1 = frameIndex;
-        const i2 = i1 + inc;
+        const i2 = steppedFrameIndex(frameIndex, inc, numFrames);
+        if (i2 === undefined) return;
         const tt = await timeseriesTimestampsClient.getTimestampsForDataIndices(
           i2,
           i2 + 1,
@@ -193,9 +195,11 @@ export const TwoPhotonSeriesItemView: FunctionComponent<Props> = ({
           throw Error("Unexpected: unable to get timestamps for data indices");
         }
         setCurrentTime(tt[0]);
-      })();
+      })().catch((err) => {
+        console.error("Unable to step to the next frame:", err);
+      });
     },
-    [timeseriesTimestampsClient, frameIndex, setCurrentTime],
+    [timeseriesTimestampsClient, frameIndex, numFrames, setCurrentTime],
   );
 
   useEffect(() => {
@@ -248,17 +252,13 @@ export const TwoPhotonSeriesItemView: FunctionComponent<Props> = ({
       >
         <div style={{ position: "relative", top: 3 }}>
           <SmallIconButton
-            disabled={
-              (currentTime || 0) <= (timeseriesTimestampsClient?.startTime || 0)
-            }
+            disabled={!canStepFrame(frameIndex, -1, numFrames)}
             title="Previous frame"
             onClick={() => incrementFrame(-1)}
             icon={<ArrowLeft />}
           />
           <SmallIconButton
-            disabled={
-              (currentTime || 0) >= (timeseriesTimestampsClient?.endTime || 0)
-            }
+            disabled={!canStepFrame(frameIndex, 1, numFrames)}
             title="Next frame"
             onClick={() => incrementFrame(1)}
             icon={<ArrowRight />}

--- a/src/pages/NwbPage/plugins/TwoPhotonSeries/TwoPhotonSeriesItemView/frameStepping.test.ts
+++ b/src/pages/NwbPage/plugins/TwoPhotonSeries/TwoPhotonSeriesItemView/frameStepping.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  canStepFrame,
+  clampFrameIndex,
+  steppedFrameIndex,
+} from "./frameStepping";
+
+describe("clampFrameIndex", () => {
+  it("keeps indices inside the dataset", () => {
+    expect(clampFrameIndex(-1, 10)).toBe(0);
+    expect(clampFrameIndex(0, 10)).toBe(0);
+    expect(clampFrameIndex(9, 10)).toBe(9);
+    expect(clampFrameIndex(10, 10)).toBe(9);
+    expect(clampFrameIndex(500, 10)).toBe(9);
+  });
+  it("returns 0 for an empty dataset", () => {
+    expect(clampFrameIndex(3, 0)).toBe(0);
+  });
+});
+
+describe("steppedFrameIndex", () => {
+  it("steps forward and backward inside the range", () => {
+    expect(steppedFrameIndex(4, 1, 10)).toBe(5);
+    expect(steppedFrameIndex(4, -1, 10)).toBe(3);
+  });
+  it("does not step past the last frame", () => {
+    // This is the case that used to request frame N and reject.
+    expect(steppedFrameIndex(9, 1, 10)).toBeUndefined();
+  });
+  it("does not step before the first frame", () => {
+    expect(steppedFrameIndex(0, -1, 10)).toBeUndefined();
+  });
+  it("clamps a large step to the boundary", () => {
+    expect(steppedFrameIndex(8, 5, 10)).toBe(9);
+    expect(steppedFrameIndex(1, -5, 10)).toBe(0);
+  });
+  it("returns undefined when the frame or size is unknown", () => {
+    expect(steppedFrameIndex(undefined, 1, 10)).toBeUndefined();
+    expect(steppedFrameIndex(3, 1, undefined)).toBeUndefined();
+  });
+});
+
+describe("canStepFrame", () => {
+  it("enables buttons only when a step would move", () => {
+    expect(canStepFrame(0, -1, 10)).toBe(false);
+    expect(canStepFrame(0, 1, 10)).toBe(true);
+    expect(canStepFrame(9, 1, 10)).toBe(false);
+    expect(canStepFrame(9, -1, 10)).toBe(true);
+    expect(canStepFrame(undefined, 1, 10)).toBe(false);
+    expect(canStepFrame(0, 1, 1)).toBe(false);
+  });
+});

--- a/src/pages/NwbPage/plugins/TwoPhotonSeries/TwoPhotonSeriesItemView/frameStepping.ts
+++ b/src/pages/NwbPage/plugins/TwoPhotonSeries/TwoPhotonSeriesItemView/frameStepping.ts
@@ -1,0 +1,26 @@
+// Frame navigation for image series: steps are clamped to the frames that
+// exist, so a click on "Next" at the last frame (or "Previous" at the
+// first) never asks the data layer for a frame outside the dataset.
+
+export const clampFrameIndex = (index: number, numFrames: number): number => {
+  if (numFrames <= 0) return 0;
+  return Math.min(Math.max(index, 0), numFrames - 1);
+};
+
+// The frame reached by stepping `inc` frames from `current`, or undefined
+// when the step would not move (already at the boundary, or nothing known).
+export const steppedFrameIndex = (
+  current: number | undefined,
+  inc: number,
+  numFrames: number | undefined,
+): number | undefined => {
+  if (current === undefined || numFrames === undefined) return undefined;
+  const next = clampFrameIndex(current + inc, numFrames);
+  return next === current ? undefined : next;
+};
+
+export const canStepFrame = (
+  current: number | undefined,
+  inc: number,
+  numFrames: number | undefined,
+): boolean => steppedFrameIndex(current, inc, numFrames) !== undefined;


### PR DESCRIPTION
Fixes #512.

The Previous and Next buttons in the TwoPhotonSeries view were disabled by comparing the current time with the series start and end times, and `incrementFrame` added the step to the frame index without checking bounds. With a `timestamps` dataset the nearest-index lookup can place the current frame at the last index while the time is still below the end time, so Next stayed enabled and the click requested frame `N`; the data layer rejected the slice inside an unawaited async block, which showed up as an unhandled rejection.

`frameStepping.ts` adds `clampFrameIndex`, `steppedFrameIndex` (the target frame, or undefined when a step would not move), and `canStepFrame`. The view uses them for both the step and the disabled state, taking the frame count from the data dataset's first dimension, and the async step now catches and logs errors. Tests cover clamping at both ends and for an empty dataset, forward and backward steps, the no-op at each boundary (the case that used to request frame `N`), large steps, unknown frame or size, and the button predicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c