### PR TITLE
Ignore NaN interval times when computing the TimeIntervals range

### DIFF
--- a/src/pages/NwbPage/plugins/TimeIntervals/TimeIntervalsViewItem/NwbTimeIntervalsView.tsx
+++ b/src/pages/NwbPage/plugins/TimeIntervals/TimeIntervalsViewItem/NwbTimeIntervalsView.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
+import { intervalsTimeRange } from "./intervalsTimeRange";
 import { FunctionComponent, useEffect, useMemo, useState } from "react";
 import {
   getHdf5DatasetData,
@@ -75,10 +76,19 @@ const NwbTimeIntervalsView: FunctionComponent<Props> = ({
     return result;
   }, [availableColumns, startTimeData]);
 
+  // Overall range of the intervals, ignoring NaN start or stop times.
+  const timeRange = useMemo(
+    () =>
+      startTimeData && stopTimeData
+        ? intervalsTimeRange(startTimeData, stopTimeData)
+        : undefined,
+    [startTimeData, stopTimeData],
+  );
+
   useEffect(() => {
-    if (!startTimeData || !stopTimeData) return;
-    const t1 = compute_min(startTimeData);
-    const t2 = compute_max(stopTimeData);
+    if (!timeRange) return;
+    const t1 = timeRange.startTime;
+    const t2 = timeRange.endTime;
     const t2b = Math.min(t1 + 100, t2);
     initializeTimeseriesSelection({
       startTimeSec: t1,
@@ -86,15 +96,17 @@ const NwbTimeIntervalsView: FunctionComponent<Props> = ({
       initialVisibleStartTimeSec: t1,
       initialVisibleEndTimeSec: t2b,
     });
-  }, [
-    startTimeData,
-    stopTimeData,
-    initializeTimeseriesSelection,
-    setVisibleTimeRange,
-  ]);
+  }, [timeRange, initializeTimeseriesSelection, setVisibleTimeRange]);
 
   if (!startTimeData || !stopTimeData) {
     return <div>loading data (NwbTimeIntervalsView)...</div>;
+  }
+  if (!timeRange) {
+    return (
+      <div style={{ padding: 10 }}>
+        This table has no finite start or stop times to display.
+      </div>
+    );
   }
 
   const handleDecreaseVisibleDuration = () => {
@@ -151,14 +163,11 @@ const NwbTimeIntervalsView: FunctionComponent<Props> = ({
           >
             <div>
               <span style={{ fontWeight: "bold" }}>Start:</span>{" "}
-              {compute_min(startTimeData).toFixed(2)}s
+              {timeRange.startTime.toFixed(2)}s
             </div>
             <div>
               <span style={{ fontWeight: "bold" }}>Duration:</span>{" "}
-              {(compute_max(stopTimeData) - compute_min(startTimeData)).toFixed(
-                2,
-              )}
-              s
+              {(timeRange.endTime - timeRange.startTime).toFixed(2)}s
             </div>
             <div>
               <span style={{ fontWeight: "bold" }}>Intervals:</span>{" "}
@@ -174,10 +183,8 @@ const NwbTimeIntervalsView: FunctionComponent<Props> = ({
                   ? visibleEndTimeSec - visibleStartTimeSec
                   : undefined
               }
-              timeseriesStartTime={compute_min(startTimeData)}
-              timeseriesDuration={
-                compute_max(stopTimeData) - compute_min(startTimeData)
-              }
+              timeseriesStartTime={timeRange.startTime}
+              timeseriesDuration={timeRange.endTime - timeRange.startTime}
               onDecreaseVisibleDuration={handleDecreaseVisibleDuration}
               onIncreaseVisibleDuration={handleIncreaseVisibleDuration}
               onShiftTimeLeft={handleShiftTimeLeft}
@@ -380,22 +387,6 @@ const getDistinctValues = (values: string[]) => {
     ret.add(val);
   }
   return Array.from(ret).sort();
-};
-
-const compute_min = (data: Float32Array) => {
-  let min = data[0];
-  for (let i = 1; i < data.length; i++) {
-    if (data[i] < min) min = data[i];
-  }
-  return min;
-};
-
-const compute_max = (data: Float32Array) => {
-  let max = data[0];
-  for (let i = 1; i < data.length; i++) {
-    if (data[i] > max) max = data[i];
-  }
-  return max;
 };
 
 export default NwbTimeIntervalsView;

--- a/src/pages/NwbPage/plugins/TimeIntervals/TimeIntervalsViewItem/NwbTimeIntervalsWidget.tsx
+++ b/src/pages/NwbPage/plugins/TimeIntervals/TimeIntervalsViewItem/NwbTimeIntervalsWidget.tsx
@@ -40,17 +40,6 @@ const NwbTimeIntervalsWidget: FunctionComponent<Props> = ({
     HTMLCanvasElement | undefined
   >();
 
-  // Calculate min/max times for reference, but don't use them to initialize the time range
-  useMemo(() => {
-    let startTime = Number.MAX_VALUE;
-    let endTime = Number.MIN_VALUE;
-    for (let i = 0; i < startTimes.length; i++) {
-      if (!isNaN(startTimes[i])) startTime = Math.min(startTime, startTimes[i]);
-      if (!isNaN(stopTimes[i])) endTime = Math.max(endTime, stopTimes[i]);
-    }
-    return { startTime, endTime };
-  }, [startTimes, stopTimes]);
-
   // We don't need to initialize the time range here as it's already initialized in the parent component
   // and we want to maintain the same time range when switching between views
   const { visibleStartTimeSec, visibleEndTimeSec } = useTimeRange();

--- a/src/pages/NwbPage/plugins/TimeIntervals/TimeIntervalsViewItem/intervalsTimeRange.test.ts
+++ b/src/pages/NwbPage/plugins/TimeIntervals/TimeIntervalsViewItem/intervalsTimeRange.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { intervalsTimeRange } from "./intervalsTimeRange";
+
+describe("intervalsTimeRange", () => {
+  it("spans from the earliest start to the latest stop", () => {
+    expect(
+      intervalsTimeRange(
+        Float32Array.from([5, 1, 3]),
+        Float32Array.from([6, 2, 4]),
+      ),
+    ).toEqual({ startTime: 1, endTime: 6 });
+  });
+
+  it("ignores a NaN in the first start time", () => {
+    // compute_min started from data[0], so a NaN there poisoned the range.
+    expect(
+      intervalsTimeRange(
+        Float32Array.from([NaN, 1, 3]),
+        Float32Array.from([0.5, 2, 4]),
+      ),
+    ).toEqual({ startTime: 0.5, endTime: 4 });
+  });
+
+  it("ignores NaN stop times and falls back to the start", () => {
+    expect(
+      intervalsTimeRange(
+        Float32Array.from([1, 3, 10]),
+        Float32Array.from([2, NaN, NaN]),
+      ),
+    ).toEqual({ startTime: 1, endTime: 10 });
+  });
+
+  it("returns undefined when no time is finite", () => {
+    expect(
+      intervalsTimeRange(Float32Array.from([NaN]), Float32Array.from([NaN])),
+    ).toBeUndefined();
+    expect(intervalsTimeRange([], [])).toBeUndefined();
+    expect(intervalsTimeRange([Infinity], [-Infinity])).toBeUndefined();
+  });
+
+  it("accepts plain arrays and mismatched lengths", () => {
+    expect(intervalsTimeRange([2, 4], [3])).toEqual({
+      startTime: 2,
+      endTime: 4,
+    });
+  });
+});

--- a/src/pages/NwbPage/plugins/TimeIntervals/TimeIntervalsViewItem/intervalsTimeRange.ts
+++ b/src/pages/NwbPage/plugins/TimeIntervals/TimeIntervalsViewItem/intervalsTimeRange.ts
@@ -1,0 +1,30 @@
+// The overall time span of a set of intervals, ignoring NaN entries.
+// Some files carry NaN start or stop times (an unfinished last trial, or a
+// column filled in later), and a plain min/max would turn the whole range
+// into NaN, which then reaches the timeseries selection and blanks the view.
+// Stops fall back to starts so an interval with an unknown stop still
+// counts toward the end of the range.
+export const intervalsTimeRange = (
+  startTimes: ArrayLike<number>,
+  stopTimes: ArrayLike<number>,
+): { startTime: number; endTime: number } | undefined => {
+  let startTime = Infinity;
+  let endTime = -Infinity;
+  const n = Math.max(startTimes.length, stopTimes.length);
+  for (let i = 0; i < n; i++) {
+    const s = startTimes[i];
+    const e = stopTimes[i];
+    if (Number.isFinite(s)) {
+      if (s < startTime) startTime = s;
+      if (s > endTime) endTime = s;
+    }
+    if (Number.isFinite(e)) {
+      if (e > endTime) endTime = e;
+      if (e < startTime) startTime = e;
+    }
+  }
+  if (!Number.isFinite(startTime) || !Number.isFinite(endTime)) {
+    return undefined;
+  }
+  return { startTime, endTime };
+};


### PR DESCRIPTION
Fixes #514.

`compute_min` and `compute_max` in the TimeIntervals view seeded their result with the first element and compared with `<` and `>`, so a NaN in `start_time[0]` or `stop_time[0]` turned the whole range into NaN. That reached `initializeTimeseriesSelection` and the header, and every downstream time comparison then failed, the same failure class as #437.

The range now comes from `intervalsTimeRange` in `intervalsTimeRange.ts`: it skips non-finite entries, lets an interval whose stop is NaN still extend the range through its start, and returns `undefined` when no time is finite, in which case the view shows a short message rather than initializing the selection with NaN. The header and the time range controls read from the same memoized range. The widget's inline NaN-skipping loop, whose result was never used, is removed.

Tests in `intervalsTimeRange.test.ts` cover the ordinary case, a NaN first start (the case the old code mishandled), NaN stops, all-NaN, empty, and infinite input, and plain arrays with mismatched lengths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TyZs4Yz25XftSqX8mJrg1c