### PR TITLE
Interval-aligned TimeSeries

### DIFF
--- a/src/pages/NwbPage/NwbHierarchyView.tsx
+++ b/src/pages/NwbPage/NwbHierarchyView.tsx
@@ -7,7 +7,7 @@ import {
 } from "react";
 import "@css/NwbHierarchyView.css";
 import { NeurodataObject, useNeurodataObjects } from "./useNeurodataObjects";
-import { findSuitablePlugins } from "./plugins/registry";
+import { findSuitablePlugins, nwbObjectViewPlugins } from "./plugins/registry";
 import { NwbObjectViewPlugin } from "./plugins/pluginInterface";
 import { useNwbFileSpecifications } from "./SpecificationsView/SetupNwbFileSpecificationsProvider";
 import { neurodataTypeInheritsFrom } from "./neurodataTypeInheritance";
@@ -94,6 +94,11 @@ const NwbHierarchyView: FunctionComponent<Props> = ({
       } = {};
       for (const obj of neurodataObjects) {
         const objectType = obj.group ? "group" : "dataset";
+        const entries: {
+          plugin: NwbObjectViewPlugin;
+          secondaryPaths: string[];
+        }[] = [];
+
         const plugins = await findSuitablePlugins(
           nwbUrl,
           obj.path,
@@ -105,15 +110,45 @@ const NwbHierarchyView: FunctionComponent<Props> = ({
           },
         );
         if (canceled) return;
-        if (plugins.length > 0) {
-          newLaunchablePluginsWithSecondaryPaths[obj.path] = plugins.map(
-            (plugin) => ({
-              plugin,
-              secondaryPaths: plugin.requiredDefaultUnits
-                ? [defaultUnitsPath!]
-                : [],
-            }),
-          );
+        for (const plugin of plugins) {
+          entries.push({
+            plugin,
+            secondaryPaths: plugin.requiredDefaultUnits
+              ? [defaultUnitsPath!]
+              : [],
+          });
+        }
+
+        // Plugins whose secondary object is derived from the full file (e.g.
+        // aligning a TimeSeries against this TimeIntervals table). A button is
+        // only shown when a compatible partner exists and canHandle confirms it.
+        for (const plugin of nwbObjectViewPlugins) {
+          if (!plugin.launchableFromTable) continue;
+          if (!plugin.getLaunchSecondaryPaths) continue;
+          const candidateList = await plugin.getLaunchSecondaryPaths({
+            nwbUrl,
+            path: obj.path,
+            objectType,
+            neurodataObjects,
+          });
+          if (canceled) return;
+          for (const secondaryPaths of candidateList) {
+            const ok = await plugin.canHandle({
+              nwbUrl,
+              path: obj.path,
+              objectType,
+              secondaryPaths,
+              specifications,
+            });
+            if (ok) {
+              entries.push({ plugin, secondaryPaths });
+            }
+          }
+        }
+
+        if (canceled) return;
+        if (entries.length > 0) {
+          newLaunchablePluginsWithSecondaryPaths[obj.path] = entries;
         }
       }
       if (canceled) return;
@@ -370,7 +405,7 @@ const NwbHierarchyView: FunctionComponent<Props> = ({
                   const pluginString = `${plugin.name}|${[obj.path, ...secondaryPaths].join("^")}`;
                   return (
                     <div
-                      key={plugin.name}
+                      key={pluginString}
                       style={{
                         display: "flex",
                         alignItems: "center",

--- a/src/pages/NwbPage/plugins/PSTH/PSTHItemView/TrialAlignedSeriesWidget.tsx
+++ b/src/pages/NwbPage/plugins/PSTH/PSTHItemView/TrialAlignedSeriesWidget.tsx
@@ -9,65 +9,145 @@ type TrialAlignedSeriesWidgetProps = {
   groups: { group: any; color: string }[];
   windowRange: { start: number; end: number };
   alignmentVariableName: string;
+  // Display options (all optional; defaults preserve the original behavior).
+  showRawTraces?: boolean; // draw the per-trial traces (default true)
+  rawTraceAlpha?: number; // opacity of the per-trial traces, 0-1 (default 1)
+  showStdBand?: boolean; // draw dashed mean +/- N*std lines (default false)
+  stdMultiple?: number; // the multiple N of std for the band (default 1)
+  yAxisLabel?: string; // label for the value axis (default "ROI")
+  // Compute the mean (and std band) separately per group, drawn in each
+  // group's color, instead of a single black mean across all trials.
+  // Default false preserves the original behavior.
+  perGroupStats?: boolean;
+};
+
+type AverageCurve = {
+  color: string;
+  times: number[];
+  values: number[];
+  stds: number[];
+};
+
+// Mean and sample standard deviation of a set of traces interpolated onto a
+// common time grid.
+const computeMeanStd = (
+  plots: { times: number[]; values: number[] }[],
+  times: number[],
+): { values: number[]; stds: number[] } => {
+  const n = times.length;
+  const valueSums = new Array(n).fill(0);
+  const valueSqSums = new Array(n).fill(0);
+  const valueCounts = new Array(n).fill(0);
+  for (const plot of plots) {
+    const values = interpolateOntoGrid(plot.times, plot.values, times);
+    for (let i = 0; i < n; i++) {
+      if (!isNaN(values[i])) {
+        valueSums[i] += values[i];
+        valueSqSums[i] += values[i] * values[i];
+        valueCounts[i] += 1;
+      }
+    }
+  }
+  const values: number[] = [];
+  const stds: number[] = [];
+  for (let i = 0; i < n; i++) {
+    const c = valueCounts[i];
+    if (c !== 0) {
+      const mean = valueSums[i] / c;
+      values.push(mean);
+      if (c > 1) {
+        const variance = Math.max(
+          0,
+          (valueSqSums[i] - c * mean * mean) / (c - 1),
+        );
+        stds.push(Math.sqrt(variance));
+      } else {
+        stds.push(NaN);
+      }
+    } else {
+      values.push(NaN);
+      stds.push(NaN);
+    }
+  }
+  return { values, stds };
 };
 
 const TrialAlignedSeriesWidget: FunctionComponent<
   TrialAlignedSeriesWidgetProps
-> = ({ width, height, trials, groups, windowRange }) => {
-  const plots: { times: number[]; values: number[]; color: string }[] =
-    useMemo(() => {
-      const colorsByGroup: { [key: number | string]: string } = {};
-      for (const g of groups) {
-        colorsByGroup[g.group] = g.color;
-      }
-      const ret: { times: number[]; values: number[]; color: string }[] = [];
-      for (let j = 0; j < trials.length; j++) {
-        const groupColor = colorsByGroup[trials[j].group];
-        if (!groupColor) continue;
-        ret.push({
-          times: trials[j].times,
-          values: trials[j].roiValues || [],
-          color: groupColor,
-        });
-      }
-      return ret;
-    }, [trials, groups]);
-  const averagePlot: { times: number[]; values: number[] } = useMemo(() => {
+> = ({
+  width,
+  height,
+  trials,
+  groups,
+  windowRange,
+  showRawTraces = true,
+  rawTraceAlpha = 1,
+  showStdBand = false,
+  stdMultiple = 1,
+  yAxisLabel = "ROI",
+  perGroupStats = false,
+}) => {
+  const plots: {
+    times: number[];
+    values: number[];
+    color: string;
+  }[] = useMemo(() => {
+    const colorsByGroup: { [key: number | string]: string } = {};
+    for (const g of groups) {
+      colorsByGroup[g.group] = g.color;
+    }
+    const ret: { times: number[]; values: number[]; color: string }[] = [];
+    for (let j = 0; j < trials.length; j++) {
+      const groupColor = colorsByGroup[trials[j].group];
+      if (!groupColor) continue;
+      ret.push({
+        times: trials[j].times,
+        values: trials[j].roiValues || [],
+        color: groupColor,
+      });
+    }
+    return ret;
+  }, [trials, groups]);
+  // One mean/std curve overall, or one per group when perGroupStats is set.
+  const averageCurves: AverageCurve[] = useMemo(() => {
     const times: number[] = [];
     for (let i = 0; i < 200; i++) {
       times.push(
         windowRange.start + ((windowRange.end - windowRange.start) * i) / 200,
       );
     }
-    const valueSums = new Array(200).fill(0);
-    const valueCounts = new Array(200).fill(0);
-    for (const plot of plots) {
-      const values = interpolateOntoGrid(plot.times, plot.values, times);
-      for (let i = 0; i < 200; i++) {
-        if (!isNaN(values[i])) {
-          valueSums[i] += values[i];
-          valueCounts[i] += 1;
-        }
-      }
+    if (!perGroupStats) {
+      const { values, stds } = computeMeanStd(plots, times);
+      return [{ color: "black", times, values, stds }];
     }
-    const values: number[] = [];
-    for (let i = 0; i < 200; i++) {
-      if (valueCounts[i] !== 0) {
-        values.push(valueSums[i] / valueCounts[i]);
-      } else {
-        values.push(NaN);
-      }
+    // Group the traces by color (each group has a distinct color).
+    const byColor = new Map<string, { times: number[]; values: number[] }[]>();
+    for (const p of plots) {
+      const arr = byColor.get(p.color);
+      if (arr) arr.push(p);
+      else byColor.set(p.color, [p]);
     }
-    return { times, values };
-  }, [plots, windowRange]);
+    const curves: AverageCurve[] = [];
+    for (const [color, groupPlots] of byColor.entries()) {
+      const { values, stds } = computeMeanStd(groupPlots, times);
+      curves.push({ color, times, values, stds });
+    }
+    return curves;
+  }, [plots, windowRange, perGroupStats]);
   return (
     <PlotChild
       width={width}
       height={height}
       plots={plots}
-      averagePlot={averagePlot}
+      averageCurves={averageCurves}
       windowRange={windowRange}
       maxNumRois={50}
+      showRawTraces={showRawTraces}
+      rawTraceAlpha={rawTraceAlpha}
+      showStdBand={showStdBand}
+      stdMultiple={stdMultiple}
+      yAxisLabel={yAxisLabel}
+      perGroupStats={perGroupStats}
     />
   );
 };
@@ -76,18 +156,30 @@ type PlotChildProps = {
   width: number;
   height: number;
   plots: { times: number[]; values: number[]; color: string }[];
-  averagePlot: { times: number[]; values: number[] };
+  averageCurves: AverageCurve[];
   windowRange: { start: number; end: number };
   maxNumRois: number;
+  showRawTraces: boolean;
+  rawTraceAlpha: number;
+  showStdBand: boolean;
+  stdMultiple: number;
+  yAxisLabel: string;
+  perGroupStats: boolean;
 };
 
 const PlotChild: FunctionComponent<PlotChildProps> = ({
   width,
   height,
   plots,
-  averagePlot,
+  averageCurves,
   windowRange,
   maxNumRois,
+  showRawTraces,
+  rawTraceAlpha,
+  showStdBand,
+  stdMultiple,
+  yAxisLabel,
+  perGroupStats,
 }) => {
   const [canvasElement, setCanvasElement] = useState<
     HTMLCanvasElement | undefined
@@ -105,10 +197,31 @@ const PlotChild: FunctionComponent<PlotChildProps> = ({
     const sortedValues = allValues
       .filter((v) => !isNaN(v))
       .sort((a, b) => a - b);
-    const minValue = sortedValues[Math.floor(sortedValues.length * 0.005)];
-    const maxValue = sortedValues[Math.floor(sortedValues.length * 0.995)];
+    let minValue = sortedValues[Math.floor(sortedValues.length * 0.005)];
+    let maxValue = sortedValues[Math.floor(sortedValues.length * 0.995)];
+    // Make sure the std band fits within the displayed range.
+    if (showStdBand) {
+      for (const curve of averageCurves) {
+        for (let i = 0; i < curve.values.length; i++) {
+          const m = curve.values[i];
+          const s = curve.stds[i];
+          if (isNaN(m) || isNaN(s)) continue;
+          const lo = m - stdMultiple * s;
+          const hi = m + stdMultiple * s;
+          if (isNaN(minValue) || lo < minValue) minValue = lo;
+          if (isNaN(maxValue) || hi > maxValue) maxValue = hi;
+        }
+      }
+    }
+    if (!isFinite(minValue) || !isFinite(maxValue)) {
+      minValue = 0;
+      maxValue = 1;
+    }
+    if (minValue === maxValue) {
+      maxValue = minValue + 1;
+    }
     return { minValue, maxValue };
-  }, [plots]);
+  }, [plots, showStdBand, stdMultiple, averageCurves]);
   const coordToPixel = useMemo(
     () => (t: number, v: number) => {
       const x =
@@ -143,42 +256,83 @@ const PlotChild: FunctionComponent<PlotChildProps> = ({
     ctx.font = "12px sans-serif";
 
     // plots
-    plotsSampled.forEach((p) => {
-      ctx.strokeStyle = p.color;
-      ctx.lineWidth = 0.5;
+    if (showRawTraces) {
+      ctx.globalAlpha = rawTraceAlpha;
+      plotsSampled.forEach((p) => {
+        ctx.strokeStyle = p.color;
+        ctx.lineWidth = 0.5;
+        ctx.beginPath();
+        if (p.values.length === 0) return;
+        const p0 = coordToPixel(windowRange.start, p.values[0]);
+        ctx.moveTo(p0.x, p0.y);
+        for (let i = 1; i < p.values.length; i++) {
+          const t = p.times[i];
+          const v = p.values[i];
+          const p1 = coordToPixel(t, v);
+          ctx.lineTo(p1.x, p1.y);
+        }
+        ctx.stroke();
+      });
+      ctx.globalAlpha = 1;
+    }
+    // mean curve(s): one black line overall, or one per group in its color.
+    const meanLineWidth = perGroupStats ? 3 : 4;
+    for (const curve of averageCurves) {
+      ctx.strokeStyle = curve.color;
+      ctx.lineWidth = meanLineWidth;
       ctx.beginPath();
-      if (p.values.length === 0) return;
-      const p0 = coordToPixel(windowRange.start, p.values[0]);
-      ctx.moveTo(p0.x, p0.y);
-      for (let i = 1; i < p.values.length; i++) {
-        const t = p.times[i];
-        const v = p.values[i];
+      let active = false;
+      for (let i = 0; i < curve.values.length; i++) {
+        const t = curve.times[i];
+        const v = curve.values[i];
+        if (isNaN(v)) {
+          active = false;
+          continue;
+        }
         const p1 = coordToPixel(t, v);
-        ctx.lineTo(p1.x, p1.y);
+        if (!active) {
+          ctx.moveTo(p1.x, p1.y);
+          active = true;
+        } else {
+          ctx.lineTo(p1.x, p1.y);
+        }
       }
       ctx.stroke();
-    });
-    //average plot
-    ctx.strokeStyle = "black";
-    ctx.lineWidth = 4;
-    ctx.beginPath();
-    let active = false;
-    for (let i = 0; i < averagePlot.values.length; i++) {
-      const t = averagePlot.times[i];
-      const v = averagePlot.values[i];
-      if (isNaN(v)) {
-        active = false;
-        continue;
-      }
-      const p1 = coordToPixel(t, v);
-      if (!active) {
-        ctx.moveTo(p1.x, p1.y);
-        active = true;
-      } else {
-        ctx.lineTo(p1.x, p1.y);
-      }
     }
-    ctx.stroke();
+
+    // mean +/- N*std as dashed lines (per curve, in the curve's color)
+    if (showStdBand) {
+      const drawBand = (curve: AverageCurve, sign: number) => {
+        ctx.beginPath();
+        let bandActive = false;
+        for (let i = 0; i < curve.values.length; i++) {
+          const t = curve.times[i];
+          const m = curve.values[i];
+          const s = curve.stds[i];
+          if (isNaN(m) || isNaN(s)) {
+            bandActive = false;
+            continue;
+          }
+          const p1 = coordToPixel(t, m + sign * stdMultiple * s);
+          if (!bandActive) {
+            ctx.moveTo(p1.x, p1.y);
+            bandActive = true;
+          } else {
+            ctx.lineTo(p1.x, p1.y);
+          }
+        }
+        ctx.stroke();
+      };
+      ctx.save();
+      ctx.setLineDash([5, 4]);
+      ctx.lineWidth = 1.5;
+      for (const curve of averageCurves) {
+        ctx.strokeStyle = perGroupStats ? curve.color : "#333";
+        drawBand(curve, 1);
+        drawBand(curve, -1);
+      }
+      ctx.restore();
+    }
 
     // y axis
     ctx.strokeStyle = "gray";
@@ -189,7 +343,6 @@ const PlotChild: FunctionComponent<PlotChildProps> = ({
     ctx.stroke();
 
     // y axis label
-    const yAxisLabel = "ROI";
     ctx.fillStyle = "black";
     ctx.textAlign = "center";
     ctx.textBaseline = "bottom";
@@ -276,7 +429,13 @@ const PlotChild: FunctionComponent<PlotChildProps> = ({
     margins,
     coordToPixel,
     ticks,
-    averagePlot,
+    averageCurves,
+    showRawTraces,
+    rawTraceAlpha,
+    showStdBand,
+    stdMultiple,
+    yAxisLabel,
+    perGroupStats,
   ]);
 
   return (

--- a/src/pages/NwbPage/plugins/PSTH/PSTHItemView/components/GroupBySelection.tsx
+++ b/src/pages/NwbPage/plugins/PSTH/PSTHItemView/components/GroupBySelection.tsx
@@ -6,6 +6,7 @@ type GroupBySelectionProps = {
   setGroupByVariable: (x: string) => void;
   nwbUrl: string;
   path: string;
+  label?: string;
 };
 
 const GroupBySelectionComponent: FunctionComponent<GroupBySelectionProps> = ({
@@ -13,12 +14,13 @@ const GroupBySelectionComponent: FunctionComponent<GroupBySelectionProps> = ({
   setGroupByVariable,
   nwbUrl,
   path,
+  label = "Group trials by:",
 }) => {
   const categoricalOptions = useCategoricalOptions(nwbUrl, path);
 
   return (
     <>
-      Group trials by:&nbsp;
+      {label}&nbsp;
       <select
         value={groupByVariable}
         onChange={(evt) => {

--- a/src/pages/NwbPage/plugins/TimeAlignedSeries/TimeAlignedSeriesView.tsx
+++ b/src/pages/NwbPage/plugins/TimeAlignedSeries/TimeAlignedSeriesView.tsx
@@ -1,0 +1,1100 @@
+import { getHdf5DatasetData, getHdf5Group } from "@hdf5Interface";
+import {
+  CSSProperties,
+  FunctionComponent,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { useNeurodataObjects } from "../../useNeurodataObjects";
+import AlignToSelectionComponent from "../PSTH/PSTHItemView/components/AlignToSelection";
+import GroupBySelectionComponent from "../PSTH/PSTHItemView/components/GroupBySelection";
+import WindowRangeComponent from "../PSTH/PSTHItemView/components/WindowRange";
+import { useCategoricalOptions } from "../PSTH/PSTHItemView/hooks/useGroupByCategories";
+import TrialAlignedSeriesWidget from "../PSTH/PSTHItemView/TrialAlignedSeriesWidget";
+import TimeseriesClient from "../simple-timeseries/TimeseriesClient";
+import {
+  isTimeSeriesLikeGroup,
+  timeSeriesSamplesPerChannel,
+} from "./detection";
+import {
+  AlignedTrial,
+  loadTimeAlignedSnippets,
+} from "./loadTimeAlignedSnippets";
+
+type Props = {
+  nwbUrl: string;
+  path: string; // the TimeIntervals table
+  secondaryPaths?: string[]; // [timeseriesPath]
+  width?: number;
+  height?: number;
+  condensed?: boolean;
+};
+
+const DEFAULT_MAX_INTERVALS = 200;
+const DEFAULT_WINDOW = { start: -2.5, end: 5 };
+
+const accordionSummaryStyle: CSSProperties = {
+  cursor: "pointer",
+  padding: "4px 8px",
+  fontWeight: "bold",
+  backgroundColor: "#34495e",
+  color: "#fff",
+  userSelect: "none",
+};
+
+const seriesColor = "#1f77b4";
+
+const groupPalette = [
+  "#1f77b4",
+  "#d62728",
+  "#2ca02c",
+  "#9467bd",
+  "#ff7f0e",
+  "#17becf",
+  "#e377c2",
+  "#8c564b",
+  "#bcbd22",
+  "#7f7f7f",
+];
+const colorForGroupIndex = (i: number) => groupPalette[i % groupPalette.length];
+
+const shortName = (path: string) =>
+  path.split("/").filter(Boolean).pop() || path;
+
+const parentPath = (path: string) =>
+  path.split("/").slice(0, -1).join("/") || "/";
+
+// Label each series by its short name, disambiguating any names shared by more
+// than one series with the parenthesized parent location.
+const buildSeriesLabels = (paths: string[]): { [path: string]: string } => {
+  const counts: { [name: string]: number } = {};
+  for (const p of paths) {
+    const n = shortName(p);
+    counts[n] = (counts[n] || 0) + 1;
+  }
+  const labels: { [path: string]: string } = {};
+  for (const p of paths) {
+    const n = shortName(p);
+    labels[p] = counts[n] > 1 ? `${n} (${parentPath(p)})` : n;
+  }
+  return labels;
+};
+
+// The view persists its main selections in the URL hash (like the PSTH view) so
+// a link or reload restores them. Keys are prefixed to avoid colliding with
+// other views' hash params.
+const readHashParams = (): URLSearchParams => {
+  const h = window.location.hash;
+  return new URLSearchParams(h.startsWith("#") ? h.slice(1) : h);
+};
+
+const TimeAlignedSeriesView: FunctionComponent<Props> = ({
+  nwbUrl,
+  path,
+  secondaryPaths,
+  width = 800,
+  height = 800,
+}) => {
+  const { neurodataObjects } = useNeurodataObjects(nwbUrl);
+
+  // All timeseries-like objects in the file are candidate series to align,
+  // ordered ascending by amount of data per channel so the lightest (fastest to
+  // render) is first.
+  const seriesOptions = useMemo(
+    () =>
+      neurodataObjects
+        .filter((o) => o.group && isTimeSeriesLikeGroup(o.group.datasets))
+        .sort(
+          (a, b) =>
+            timeSeriesSamplesPerChannel(a.group!.datasets) -
+            timeSeriesSamplesPerChannel(b.group!.datasets),
+        )
+        .map((o) => o.path),
+    [neurodataObjects],
+  );
+
+  const initialSeries = secondaryPaths && secondaryPaths[0];
+  const [selectedSeriesPath, setSelectedSeriesPath] = useState<
+    string | undefined
+  >(() => readHashParams().get("ta_series") || initialSeries);
+
+  // Once the object list is known, make sure a valid series is selected.
+  useEffect(() => {
+    if (selectedSeriesPath && seriesOptions.includes(selectedSeriesPath))
+      return;
+    if (initialSeries && seriesOptions.includes(initialSeries)) {
+      setSelectedSeriesPath(initialSeries);
+      return;
+    }
+    // Keep an externally-provided series even before the object list resolves.
+    if (initialSeries && seriesOptions.length === 0) return;
+    if (seriesOptions.length > 0) setSelectedSeriesPath(seriesOptions[0]);
+  }, [seriesOptions, initialSeries, selectedSeriesPath]);
+
+  if (!selectedSeriesPath) {
+    if (seriesOptions.length === 0 && neurodataObjects.length > 0) {
+      return (
+        <div style={{ padding: 12 }}>
+          No compatible TimeSeries found in this file.
+        </div>
+      );
+    }
+    return <div style={{ padding: 12 }}>Loading timeseries...</div>;
+  }
+
+  return (
+    <TimeAlignedSeriesInner
+      nwbUrl={nwbUrl}
+      intervalsPath={path}
+      seriesPath={selectedSeriesPath}
+      seriesOptions={seriesOptions}
+      setSeriesPath={setSelectedSeriesPath}
+      width={width}
+      height={height}
+    />
+  );
+};
+
+type InnerProps = {
+  nwbUrl: string;
+  intervalsPath: string;
+  seriesPath: string;
+  seriesOptions: string[];
+  setSeriesPath: (p: string) => void;
+  width: number;
+  height: number;
+};
+
+type CommittedParams = {
+  windowRange: { start: number; end: number };
+  maxIntervals: number;
+};
+
+type Group = { group: string; color: string };
+
+const TimeAlignedSeriesInner: FunctionComponent<InnerProps> = ({
+  nwbUrl,
+  intervalsPath,
+  seriesPath,
+  seriesOptions,
+  setSeriesPath,
+  width,
+  height,
+}) => {
+  // Load a client for the selected series. Keep the previous client visible
+  // while a new series loads so the controls and existing plots don't flicker.
+  const [client, setClient] = useState<TimeseriesClient | null>(null);
+  const [clientError, setClientError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let canceled = false;
+    setClientError(null);
+    (async () => {
+      try {
+        const group = await getHdf5Group(nwbUrl, seriesPath);
+        if (!group) throw new Error(`Unable to load group: ${seriesPath}`);
+        const c = await TimeseriesClient.create(nwbUrl, group);
+        if (!canceled) setClient(c);
+      } catch (err) {
+        if (!canceled) {
+          setClient(null);
+          setClientError(err instanceof Error ? err.message : String(err));
+        }
+      }
+    })();
+    return () => {
+      canceled = true;
+    };
+  }, [nwbUrl, seriesPath]);
+
+  const numChannels = client ? client.numChannels : 1;
+
+  // Channel and align-to selections apply live (like the PSTH unit selector).
+  const [selectedChannels, setSelectedChannels] = useState<number[]>(() => {
+    const v = readHashParams().get("ta_channels");
+    if (v) {
+      const arr = v
+        .split(",")
+        .map((x) => parseInt(x))
+        .filter((n) => Number.isInteger(n) && n >= 0);
+      if (arr.length > 0) return arr;
+    }
+    return [0];
+  });
+  const [alignToVariables, setAlignToVariables] = useState<string[]>(() => {
+    const v = readHashParams().get("ta_align");
+    return v ? v.split(",").filter(Boolean) : ["start_time"];
+  });
+
+  // Keep the channel selection within range when the series changes.
+  useEffect(() => {
+    if (!client) return;
+    setSelectedChannels((prev) => {
+      const filtered = prev.filter((c) => c < client.numChannels);
+      return filtered.length > 0 ? filtered : [0];
+    });
+  }, [client]);
+
+  // Window range and max intervals require an explicit Update (they trigger
+  // reloading of the snippet data).
+  const [windowRangeStr, setWindowRangeStr] = useState<{
+    start: string;
+    end: string;
+  }>(() => {
+    const v = readHashParams().get("ta_win");
+    if (v) {
+      const parts = v.split(",");
+      if (parts.length === 2) return { start: parts[0], end: parts[1] };
+    }
+    return {
+      start: String(DEFAULT_WINDOW.start),
+      end: String(DEFAULT_WINDOW.end),
+    };
+  });
+  const [maxIntervalsStr, setMaxIntervalsStr] = useState(
+    () => readHashParams().get("ta_max") || String(DEFAULT_MAX_INTERVALS),
+  );
+  const [committed, setCommitted] = useState<CommittedParams>(() => {
+    const p = readHashParams();
+    let start = DEFAULT_WINDOW.start;
+    let end = DEFAULT_WINDOW.end;
+    const w = p.get("ta_win");
+    if (w) {
+      const [s, e] = w.split(",").map(Number);
+      if (isFinite(s) && isFinite(e) && e > s) {
+        start = s;
+        end = e;
+      }
+    }
+    const mv = parseInt(p.get("ta_max") || "");
+    const maxIntervals =
+      Number.isFinite(mv) && mv >= 1 ? mv : DEFAULT_MAX_INTERVALS;
+    return { windowRange: { start, end }, maxIntervals };
+  });
+  const [paramError, setParamError] = useState<string | null>(null);
+
+  const handleUpdate = () => {
+    const start = parseFloat(windowRangeStr.start);
+    const end = parseFloat(windowRangeStr.end);
+    if (isNaN(start) || isNaN(end)) {
+      setParamError("Invalid window range.");
+      return;
+    }
+    if (end <= start) {
+      setParamError("Window end must be greater than start.");
+      return;
+    }
+    const maxIntervals = parseInt(maxIntervalsStr);
+    if (isNaN(maxIntervals) || maxIntervals < 1) {
+      setParamError("Invalid maximum number of intervals.");
+      return;
+    }
+    setParamError(null);
+    setCommitted({ windowRange: { start, end }, maxIntervals });
+  };
+
+  // Display options apply live (no data reload). Opacity 0 hides raw traces,
+  // so no separate checkbox is needed.
+  const [rawTraceAlpha, setRawTraceAlpha] = useState(0.4);
+  const [showStdBand, setShowStdBand] = useState(true);
+  const [stdMultipleStr, setStdMultipleStr] = useState("1");
+  const stdMultiple = useMemo(() => {
+    const v = parseFloat(stdMultipleStr);
+    return isNaN(v) || v < 0 ? 1 : v;
+  }, [stdMultipleStr]);
+  // Redrawing the std lines across every panel is expensive, so debounce: apply
+  // the new multiple only ~5s after the user stops changing it.
+  const [effectiveStdMultiple, setEffectiveStdMultiple] = useState(1);
+  useEffect(() => {
+    if (effectiveStdMultiple === stdMultiple) return;
+    const t = setTimeout(() => setEffectiveStdMultiple(stdMultiple), 5000);
+    return () => clearTimeout(t);
+  }, [stdMultiple, effectiveStdMultiple]);
+  const stdPending = showStdBand && effectiveStdMultiple !== stdMultiple;
+  // How to show groups: overlaid on one plot, or split into side-by-side plots.
+  const [groupDisplay, setGroupDisplay] = useState<"overlay" | "split">(() =>
+    readHashParams().get("ta_groupdisp") === "split" ? "split" : "overlay",
+  );
+
+  // Group by (live). Only offered when the table has categorical columns.
+  const categoricalOptions = useCategoricalOptions(nwbUrl, intervalsPath);
+  const [groupByVariable, setGroupByVariable] = useState<string>(
+    () => readHashParams().get("ta_groupby") || "",
+  );
+
+  const [groupByValues, setGroupByValues] = useState<string[] | undefined>(
+    undefined,
+  );
+  useEffect(() => {
+    if (!groupByVariable) {
+      setGroupByValues(undefined);
+      return;
+    }
+    let canceled = false;
+    (async () => {
+      const dd = await getHdf5DatasetData(
+        nwbUrl,
+        intervalsPath + "/" + groupByVariable,
+        {},
+      );
+      if (canceled || !dd) return;
+      setGroupByValues(
+        [...dd].map((x) => (x as { toString(): string }).toString()),
+      );
+    })();
+    return () => {
+      canceled = true;
+    };
+  }, [nwbUrl, intervalsPath, groupByVariable]);
+
+  const groups: Group[] | undefined = useMemo(() => {
+    if (!groupByVariable) return undefined;
+    const opt = categoricalOptions?.find(
+      (o) => o.variableName === groupByVariable,
+    );
+    const cats = opt
+      ? [...opt.categories].sort()
+      : groupByValues
+        ? [...new Set(groupByValues)].sort()
+        : [];
+    return cats.map((c, i) => ({ group: c, color: colorForGroupIndex(i) }));
+  }, [groupByVariable, categoricalOptions, groupByValues]);
+
+  // Number of intervals (traces) per group that go into each average, capped at
+  // maxIntervals to match what is actually loaded.
+  const groupCounts = useMemo(() => {
+    if (!groupByValues) return undefined;
+    const counts: { [k: string]: number } = {};
+    for (const v of groupByValues.slice(0, committed.maxIntervals)) {
+      counts[v] = (counts[v] || 0) + 1;
+    }
+    return counts;
+  }, [groupByValues, committed.maxIntervals]);
+
+  // Persist the main selections in the URL hash.
+  useEffect(() => {
+    const p = readHashParams();
+    const setOrDelete = (k: string, val: string, isDefault: boolean) => {
+      if (val && !isDefault) p.set(k, val);
+      else p.delete(k);
+    };
+    if (seriesPath) p.set("ta_series", seriesPath);
+    else p.delete("ta_series");
+    setOrDelete(
+      "ta_channels",
+      selectedChannels.join(","),
+      selectedChannels.length === 1 && selectedChannels[0] === 0,
+    );
+    setOrDelete(
+      "ta_align",
+      alignToVariables.join(","),
+      alignToVariables.length === 1 && alignToVariables[0] === "start_time",
+    );
+    setOrDelete(
+      "ta_win",
+      `${committed.windowRange.start},${committed.windowRange.end}`,
+      committed.windowRange.start === DEFAULT_WINDOW.start &&
+        committed.windowRange.end === DEFAULT_WINDOW.end,
+    );
+    setOrDelete(
+      "ta_max",
+      String(committed.maxIntervals),
+      committed.maxIntervals === DEFAULT_MAX_INTERVALS,
+    );
+    setOrDelete("ta_groupby", groupByVariable, groupByVariable === "");
+    setOrDelete(
+      "ta_groupdisp",
+      groupDisplay,
+      !(groupByVariable !== "" && groupDisplay === "split"),
+    );
+    const newHash = "#" + p.toString();
+    if (window.location.hash !== newHash) {
+      window.history.replaceState(null, "", newHash);
+    }
+  }, [
+    seriesPath,
+    selectedChannels,
+    alignToVariables,
+    committed,
+    groupByVariable,
+    groupDisplay,
+  ]);
+
+  // The list shown in the series dropdown (prepend the selected series if it is
+  // not among the options), with labels disambiguated by location.
+  const seriesRenderPaths = useMemo(
+    () =>
+      seriesOptions.includes(seriesPath)
+        ? seriesOptions
+        : [seriesPath, ...seriesOptions],
+    [seriesOptions, seriesPath],
+  );
+  const seriesLabels = useMemo(
+    () => buildSeriesLabels(seriesRenderPaths),
+    [seriesRenderPaths],
+  );
+
+  const controlsWidth = 260;
+  const plotAreaWidth = width - controlsWidth;
+  const gap = 8;
+  const numAlign = alignToVariables.length || 1;
+  const grouping = !!groups && !!groupByValues && groupByVariable !== "";
+  const split = grouping && groupDisplay === "split";
+  const panelWidth = Math.max(
+    240,
+    (plotAreaWidth - 20 - gap * (numAlign - 1)) / numAlign,
+  );
+  // When splitting into one plot per group, use a fixed cell width and let the
+  // channel row scroll horizontally.
+  const cellWidth = split ? 340 : panelWidth;
+  const panelHeight =
+    selectedChannels.length > 1
+      ? 320
+      : Math.min(Math.max(height - 80, 300), 480);
+  const legendActive = !!groups && groupByVariable !== "";
+
+  return (
+    <div style={{ position: "absolute", width, height, overflow: "hidden" }}>
+      <div
+        style={{
+          position: "absolute",
+          width: controlsWidth,
+          height,
+          overflowY: "auto",
+          overflowX: "hidden",
+          fontSize: "0.8em",
+        }}
+      >
+        <details open>
+          <summary style={accordionSummaryStyle}>Timeseries</summary>
+          <div style={{ padding: "6px 8px" }}>
+            <select
+              value={seriesPath}
+              onChange={(e) => setSeriesPath(e.target.value)}
+              style={{ width: "100%" }}
+              disabled={seriesOptions.length <= 1}
+            >
+              {seriesRenderPaths.map((p) => (
+                <option key={p} value={p} title={p}>
+                  {seriesLabels[p] ?? shortName(p)}
+                </option>
+              ))}
+            </select>
+            <div
+              style={{
+                color: "#666",
+                marginTop: 4,
+                wordBreak: "break-all",
+                fontSize: "0.9em",
+              }}
+            >
+              {client
+                ? `${numChannels} channel${numChannels === 1 ? "" : "s"} · ${client.samplingFrequency.toFixed(1)} Hz`
+                : "Loading series..."}
+            </div>
+          </div>
+        </details>
+        <div style={{ height: 6 }} />
+        <details open>
+          <summary style={accordionSummaryStyle}>Channels</summary>
+          <div style={{ maxHeight: 220, overflowY: "auto" }}>
+            <ChannelSelection
+              numChannels={numChannels}
+              selectedChannels={selectedChannels}
+              setSelectedChannels={setSelectedChannels}
+            />
+          </div>
+        </details>
+        <div style={{ height: 6 }} />
+        <details open>
+          <summary style={accordionSummaryStyle}>Align to</summary>
+          <AlignToSelectionComponent
+            alignToVariables={alignToVariables}
+            setAlignToVariables={setAlignToVariables}
+            nwbUrl={nwbUrl}
+            path={intervalsPath}
+          />
+        </details>
+        <div style={{ height: 6 }} />
+        <details open>
+          <summary style={accordionSummaryStyle}>Controls</summary>
+          <div style={{ padding: "6px 8px" }}>
+            <WindowRangeComponent
+              windowRangeStr={windowRangeStr}
+              setWindowRangeStr={setWindowRangeStr}
+            />
+            <br />
+            <br />
+            <label>
+              Max intervals:&nbsp;
+              <input
+                type="number"
+                min={1}
+                value={maxIntervalsStr}
+                onChange={(e) => setMaxIntervalsStr(e.target.value)}
+                style={{ width: 70 }}
+              />
+            </label>
+            {categoricalOptions && categoricalOptions.length > 0 && (
+              <div style={{ marginTop: 10 }}>
+                <GroupBySelectionComponent
+                  groupByVariable={groupByVariable}
+                  setGroupByVariable={setGroupByVariable}
+                  nwbUrl={nwbUrl}
+                  path={intervalsPath}
+                  label="Group intervals by:"
+                />
+              </div>
+            )}
+            <div style={{ marginTop: 10 }}>
+              <button
+                onClick={handleUpdate}
+                style={{
+                  padding: "6px 16px",
+                  backgroundColor: "#007bff",
+                  color: "white",
+                  border: "none",
+                  borderRadius: 4,
+                  cursor: "pointer",
+                }}
+              >
+                Update
+              </button>
+            </div>
+            {paramError && (
+              <div style={{ color: "#e74c3c", marginTop: 6 }}>{paramError}</div>
+            )}
+          </div>
+        </details>
+        <div style={{ height: 6 }} />
+        <details open>
+          <summary style={accordionSummaryStyle}>Display</summary>
+          <div style={{ padding: "6px 8px" }}>
+            <label>
+              Raw trace opacity: {rawTraceAlpha.toFixed(2)}
+              {rawTraceAlpha === 0 ? " (hidden)" : ""}
+              <br />
+              <input
+                type="range"
+                min={0}
+                max={1}
+                step={0.05}
+                value={rawTraceAlpha}
+                onChange={(e) => setRawTraceAlpha(parseFloat(e.target.value))}
+                style={{ width: "100%" }}
+              />
+            </label>
+            <hr style={{ margin: "8px 0", borderColor: "#dde4ed" }} />
+            <label style={{ display: "block" }}>
+              <input
+                type="checkbox"
+                checked={showStdBand}
+                onChange={(e) => setShowStdBand(e.target.checked)}
+              />
+              &nbsp;&plusmn;Std band (dashed)
+            </label>
+            <div style={{ marginTop: 6, opacity: showStdBand ? 1 : 0.4 }}>
+              <label>
+                Multiple (&sigma;):&nbsp;
+                <input
+                  type="number"
+                  min={0}
+                  step={0.1}
+                  value={stdMultipleStr}
+                  disabled={!showStdBand}
+                  onChange={(e) => setStdMultipleStr(e.target.value)}
+                  style={{ width: 60 }}
+                />
+              </label>
+              {stdPending && (
+                <div style={{ color: "#e67e22", marginTop: 3 }}>
+                  Re-computing...
+                </div>
+              )}
+            </div>
+            {groupByVariable !== "" && (
+              <>
+                <hr style={{ margin: "8px 0", borderColor: "#dde4ed" }} />
+                <label>
+                  Group display:&nbsp;
+                  <select
+                    value={groupDisplay}
+                    onChange={(e) =>
+                      setGroupDisplay(e.target.value as "overlay" | "split")
+                    }
+                  >
+                    <option value="overlay">Overlay</option>
+                    <option value="split">Split (side by side)</option>
+                  </select>
+                </label>
+              </>
+            )}
+          </div>
+        </details>
+      </div>
+
+      <div
+        style={{
+          position: "absolute",
+          left: controlsWidth,
+          width: plotAreaWidth,
+          height,
+          overflowY: "auto",
+          overflowX: "hidden",
+        }}
+      >
+        {legendActive && (
+          <div
+            style={{
+              display: "flex",
+              gap: 14,
+              flexWrap: "wrap",
+              alignItems: "center",
+              padding: "6px 8px",
+            }}
+          >
+            <span style={{ fontWeight: "bold" }}>{groupByVariable}:</span>
+            {groups!.map((g) => (
+              <span
+                key={g.group}
+                style={{ display: "flex", alignItems: "center", gap: 4 }}
+              >
+                <span
+                  style={{
+                    width: 14,
+                    height: 14,
+                    background: g.color,
+                    display: "inline-block",
+                  }}
+                />
+                <span>
+                  {g.group}
+                  {groupCounts ? ` (${groupCounts[g.group] ?? 0})` : ""}
+                </span>
+              </span>
+            ))}
+          </div>
+        )}
+        {clientError ? (
+          <div style={{ padding: 12, color: "#e74c3c" }}>
+            Error loading series: {clientError}
+          </div>
+        ) : !client ? (
+          <div style={{ padding: 12, color: "#555" }}>Loading series...</div>
+        ) : selectedChannels.length === 0 ? (
+          <div style={{ padding: 12 }}>Select one or more channels.</div>
+        ) : alignToVariables.length === 0 ? (
+          <div style={{ padding: 12 }}>
+            Select one or more align-to columns.
+          </div>
+        ) : (
+          selectedChannels.map((ch) => (
+            <div key={ch} style={{ marginBottom: 12 }}>
+              <div
+                style={{
+                  fontWeight: "bold",
+                  padding: "2px 8px",
+                  fontSize: 14,
+                }}
+              >
+                Channel {ch}
+              </div>
+              <div
+                style={{
+                  display: "flex",
+                  gap,
+                  overflowX: split ? "auto" : "hidden",
+                  maxWidth: plotAreaWidth - 4,
+                }}
+              >
+                {alignToVariables.map((alignToVariable) => (
+                  <AlignBlock
+                    key={alignToVariable}
+                    nwbUrl={nwbUrl}
+                    intervalsPath={intervalsPath}
+                    client={client}
+                    alignToVariable={alignToVariable}
+                    channel={ch}
+                    windowRange={committed.windowRange}
+                    maxIntervals={committed.maxIntervals}
+                    cellWidth={cellWidth}
+                    cellHeight={panelHeight}
+                    gap={gap}
+                    rawTraceAlpha={rawTraceAlpha}
+                    showStdBand={showStdBand}
+                    stdMultiple={effectiveStdMultiple}
+                    groupByValues={groupByValues}
+                    groups={groups}
+                    split={split}
+                    yAxisLabel={`ch ${ch}`}
+                  />
+                ))}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+};
+
+type ChannelSelectionProps = {
+  numChannels: number;
+  selectedChannels: number[];
+  setSelectedChannels: (x: number[] | ((prev: number[]) => number[])) => void;
+};
+
+const ChannelSelection: FunctionComponent<ChannelSelectionProps> = ({
+  numChannels,
+  selectedChannels,
+  setSelectedChannels,
+}) => {
+  const channels = useMemo(
+    () => Array.from({ length: numChannels }, (_, i) => i),
+    [numChannels],
+  );
+  const allSelected =
+    channels.length > 0 && selectedChannels.length === channels.length;
+  return (
+    <table className="nwb-table" style={{ tableLayout: "fixed" }}>
+      <colgroup>
+        <col style={{ width: 20 }} />
+      </colgroup>
+      <thead>
+        <tr>
+          <th style={{ padding: "4px 2px" }}>
+            <input
+              type="checkbox"
+              checked={allSelected}
+              onChange={() => {}}
+              onClick={() => {
+                if (selectedChannels.length > 0) setSelectedChannels([]);
+                else setSelectedChannels(channels);
+              }}
+            />
+          </th>
+          <th>Channel</th>
+        </tr>
+      </thead>
+      <tbody>
+        {channels.map((ch) => (
+          <tr key={ch}>
+            <td style={{ padding: "4px 2px" }}>
+              <input
+                type="checkbox"
+                checked={selectedChannels.includes(ch)}
+                onChange={() => {}}
+                onClick={() => {
+                  setSelectedChannels((prev) =>
+                    prev.includes(ch)
+                      ? prev.filter((x) => x !== ch)
+                      : [...prev, ch].sort((a, b) => a - b),
+                  );
+                }}
+              />
+            </td>
+            <td>{ch}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
+
+type WidgetTrial = {
+  times: number[];
+  roiValues: number[];
+  group: string | number;
+};
+
+type AlignBlockProps = {
+  nwbUrl: string;
+  intervalsPath: string;
+  client: TimeseriesClient;
+  alignToVariable: string;
+  channel: number;
+  windowRange: { start: number; end: number };
+  maxIntervals: number;
+  cellWidth: number;
+  cellHeight: number;
+  gap: number;
+  rawTraceAlpha: number;
+  showStdBand: boolean;
+  stdMultiple: number;
+  groupByValues: string[] | undefined;
+  groups: Group[] | undefined;
+  split: boolean;
+  yAxisLabel: string;
+};
+
+// Loads the snippets for one (channel, align-to) pair once, then renders either
+// a single overlaid plot or one plot per group (split, side by side).
+const AlignBlock: FunctionComponent<AlignBlockProps> = ({
+  nwbUrl,
+  intervalsPath,
+  client,
+  alignToVariable,
+  channel,
+  windowRange,
+  maxIntervals,
+  cellWidth,
+  cellHeight,
+  gap,
+  rawTraceAlpha,
+  showStdBand,
+  stdMultiple,
+  groupByValues,
+  groups,
+  split,
+  yAxisLabel,
+}) => {
+  const [rawTrials, setRawTrials] = useState<AlignedTrial[] | null>(null);
+  const [numAlignTimes, setNumAlignTimes] = useState<number | null>(null);
+  const [progress, setProgress] = useState<{ loaded: number; total: number }>({
+    loaded: 0,
+    total: 0,
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let canceled = false;
+    const canceler = { canceled: false };
+    setRawTrials(null);
+    setError(null);
+    setProgress({ loaded: 0, total: 0 });
+    (async () => {
+      try {
+        const rawTimes = await getHdf5DatasetData(
+          nwbUrl,
+          intervalsPath + "/" + alignToVariable,
+          {},
+        );
+        if (!rawTimes)
+          throw new Error(`Unable to load ${intervalsPath}/${alignToVariable}`);
+        const alignTimes = Array.from(rawTimes as ArrayLike<number>);
+        if (canceled) return;
+        setNumAlignTimes(alignTimes.length);
+        const loaded = await loadTimeAlignedSnippets(
+          client,
+          alignTimes,
+          channel,
+          windowRange,
+          {
+            maxIntervals,
+            canceler,
+            onProgress: (loadedCount, total) => {
+              if (!canceled) setProgress({ loaded: loadedCount, total });
+            },
+          },
+        );
+        if (canceled) return;
+        setRawTrials(loaded);
+      } catch (err) {
+        if (!canceled)
+          setError(err instanceof Error ? err.message : String(err));
+      }
+    })();
+    return () => {
+      canceled = true;
+      canceler.canceled = true;
+    };
+  }, [
+    nwbUrl,
+    intervalsPath,
+    client,
+    alignToVariable,
+    channel,
+    windowRange,
+    maxIntervals,
+  ]);
+
+  // Only group once both the group definitions and the per-row values are
+  // ready; otherwise fall back to a single group (avoids a blank flash while
+  // the group-by column loads).
+  const grouping = !!groups && !!groupByValues;
+
+  // Assign a group to each trial by its row index (live; no snippet reload).
+  const allTrials: WidgetTrial[] | null = useMemo(() => {
+    if (!rawTrials) return null;
+    return rawTrials.map((tr) => ({
+      times: tr.times,
+      roiValues: tr.roiValues,
+      group: grouping ? (groupByValues![tr.index] ?? "?") : 0,
+    }));
+  }, [rawTrials, grouping, groupByValues]);
+
+  // Actual number of intervals plotted (rows with a valid alignment time,
+  // capped at maxIntervals) out of the table's total rows.
+  const countLabel = allTrials
+    ? ` (${allTrials.length}${
+        numAlignTimes !== null && allTrials.length < numAlignTimes
+          ? ` of ${numAlignTimes}`
+          : ""
+      } intervals)`
+    : "";
+
+  // Memoize the per-cell trial arrays so their references stay stable across
+  // re-renders (e.g. while the user edits an unrelated live control). Without
+  // this, new trials/groups arrays each render would invalidate the widget's
+  // interpolation memos and re-run the expensive mean/std computation.
+  const cells = useMemo(() => {
+    if (!allTrials) return null;
+    if (split && grouping) {
+      return groups!.map((g) => {
+        const trials = allTrials.filter((t) => t.group === g.group);
+        return {
+          key: String(g.group),
+          title: `${alignToVariable} · ${g.group} (${trials.length})`,
+          trials,
+          widgetGroups: [g] as Group[],
+          // Draw the mean/band in the group's color so a group looks the same
+          // in split as in overlay.
+          perGroupStats: true,
+        };
+      });
+    }
+    return [
+      {
+        key: "_all",
+        title: alignToVariable + countLabel,
+        trials: allTrials,
+        widgetGroups: (grouping
+          ? groups!
+          : [{ group: 0, color: seriesColor }]) as (
+          | Group
+          | { group: number; color: string }
+        )[],
+        perGroupStats: grouping,
+      },
+    ];
+  }, [allTrials, split, grouping, groups, alignToVariable, countLabel]);
+
+  const statusBox = (color: string, text: string) => (
+    <div
+      style={{
+        flex: "0 0 auto",
+        width: cellWidth,
+        height: cellHeight,
+        padding: 12,
+        color,
+        boxSizing: "border-box",
+      }}
+    >
+      {text}
+    </div>
+  );
+
+  if (error) return statusBox("#e74c3c", `Error: ${error}`);
+  if (!allTrials || !cells)
+    return statusBox(
+      "#555",
+      `Loading snippets... ${progress.loaded}${progress.total ? ` / ${progress.total}` : ""}`,
+    );
+  if (allTrials.length === 0)
+    return statusBox("#555", "No intervals to display.");
+
+  return (
+    <div style={{ display: "flex", gap, flex: "0 0 auto" }}>
+      {cells.map((cell) => (
+        <TrialPlot
+          key={cell.key}
+          width={cellWidth}
+          height={cellHeight}
+          title={cell.title}
+          trials={cell.trials}
+          groups={cell.widgetGroups}
+          perGroupStats={cell.perGroupStats}
+          windowRange={windowRange}
+          alignToVariable={alignToVariable}
+          rawTraceAlpha={rawTraceAlpha}
+          showStdBand={showStdBand}
+          stdMultiple={stdMultiple}
+          yAxisLabel={yAxisLabel}
+        />
+      ))}
+    </div>
+  );
+};
+
+type TrialPlotProps = {
+  width: number;
+  height: number;
+  title: string;
+  trials: WidgetTrial[];
+  groups: (Group | { group: number; color: string })[];
+  perGroupStats: boolean;
+  windowRange: { start: number; end: number };
+  alignToVariable: string;
+  rawTraceAlpha: number;
+  showStdBand: boolean;
+  stdMultiple: number;
+  yAxisLabel: string;
+};
+
+const TrialPlot: FunctionComponent<TrialPlotProps> = ({
+  width,
+  height,
+  title,
+  trials,
+  groups,
+  perGroupStats,
+  windowRange,
+  alignToVariable,
+  rawTraceAlpha,
+  showStdBand,
+  stdMultiple,
+  yAxisLabel,
+}) => {
+  const titleHeight = 22;
+  const widgetHeight = height - titleHeight;
+  return (
+    <div style={{ position: "relative", width, height, flex: "0 0 auto" }}>
+      <div
+        style={{
+          position: "absolute",
+          width,
+          height: titleHeight,
+          fontWeight: "bold",
+          textAlign: "center",
+          fontSize: 13,
+          overflow: "hidden",
+          whiteSpace: "nowrap",
+          textOverflow: "ellipsis",
+        }}
+        title={title}
+      >
+        {title}
+      </div>
+      <div
+        style={{
+          position: "absolute",
+          top: titleHeight,
+          width,
+          height: widgetHeight,
+        }}
+      >
+        {trials.length === 0 ? (
+          <div style={{ padding: 12, color: "#555" }}>No intervals.</div>
+        ) : (
+          <TrialAlignedSeriesWidget
+            width={width}
+            height={widgetHeight}
+            trials={trials}
+            groups={groups}
+            windowRange={windowRange}
+            alignmentVariableName={alignToVariable}
+            showRawTraces={rawTraceAlpha > 0}
+            rawTraceAlpha={rawTraceAlpha}
+            showStdBand={showStdBand}
+            stdMultiple={stdMultiple}
+            yAxisLabel={yAxisLabel}
+            perGroupStats={perGroupStats}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TimeAlignedSeriesView;

--- a/src/pages/NwbPage/plugins/TimeAlignedSeries/detection.ts
+++ b/src/pages/NwbPage/plugins/TimeAlignedSeries/detection.ts
@@ -1,0 +1,45 @@
+// True if the group looks like a TimeSeries with a sampled data array, i.e. it
+// has a `data` dataset (1D single-channel or 2D time-by-channel) together with
+// either explicit `timestamps` or a regular `starting_time`.
+//
+// Series with a regular `starting_time` but a non-positive `rate` (e.g. 0.0 Hz)
+// are excluded -- they have no meaningful sampling and can't be aligned. Series
+// that use `timestamps` are kept; their rate is approximated from the
+// timestamps by the TimeseriesClient.
+export const isTimeSeriesLikeGroup = (
+  datasets: {
+    name: string;
+    shape: number[];
+    attrs?: { [key: string]: unknown };
+  }[],
+): boolean => {
+  const dataDataset = datasets.find((ds) => ds.name === "data");
+  if (!dataDataset) return false;
+  const numDims = dataDataset.shape.length || 0;
+  if (![1, 2].includes(numDims)) return false;
+
+  const timestamps = datasets.find((ds) => ds.name === "timestamps");
+  if (timestamps) return true;
+
+  const startingTime = datasets.find((ds) => ds.name === "starting_time");
+  if (startingTime) {
+    const rate = Number(startingTime.attrs?.["rate"]);
+    // Exclude only when the rate is known and non-positive (e.g. 0.0 Hz). If
+    // the rate is absent from the listing, keep the series rather than risk
+    // hiding a valid one.
+    if (isFinite(rate)) return rate > 0;
+    return true;
+  }
+
+  return false;
+};
+
+// The amount of data per channel for a timeseries-like group: the number of
+// time samples (the first dimension of `data`). Used to order series so the
+// lightest one -- which loads/renders fastest -- can be the default.
+export const timeSeriesSamplesPerChannel = (
+  datasets: { name: string; shape: number[] }[],
+): number => {
+  const dataDataset = datasets.find((ds) => ds.name === "data");
+  return dataDataset?.shape[0] ?? 0;
+};

--- a/src/pages/NwbPage/plugins/TimeAlignedSeries/index.ts
+++ b/src/pages/NwbPage/plugins/TimeAlignedSeries/index.ts
@@ -1,0 +1,68 @@
+import { getHdf5Group } from "@hdf5Interface";
+import { NwbObjectViewPlugin } from "../pluginInterface";
+import {
+  isTimeSeriesLikeGroup,
+  timeSeriesSamplesPerChannel,
+} from "./detection";
+import TimeAlignedSeriesView from "./TimeAlignedSeriesView";
+
+// A time-aligned view of any TimeSeries relative to the events of a
+// TimeIntervals table. Like the PSTH, it extracts short snippets of the series
+// before and after each `_time` column of the table, overlaid across
+// repetitions, plus the trial-averaged trace.
+export const timeAlignedSeriesPlugin: NwbObjectViewPlugin = {
+  name: "TimeAlignedSeries",
+  label: "Time-aligned",
+  canHandle: async ({
+    nwbUrl,
+    path,
+    objectType,
+    secondaryPaths,
+  }: {
+    nwbUrl: string;
+    path: string;
+    objectType: "group" | "dataset";
+    secondaryPaths?: string[];
+  }) => {
+    if (objectType !== "group") return false;
+    if (!secondaryPaths) return false;
+    if (secondaryPaths.length !== 1) return false;
+
+    // Primary object must be a TimeIntervals table.
+    const group = await getHdf5Group(nwbUrl, path);
+    if (!group) return false;
+    if (group.attrs["neurodata_type"] !== "TimeIntervals") return false;
+
+    // Secondary object must be a timeseries-like group.
+    const secondaryGroup = await getHdf5Group(nwbUrl, secondaryPaths[0]);
+    if (!secondaryGroup) return false;
+    return isTimeSeriesLikeGroup(secondaryGroup.datasets);
+  },
+  // Show a "Time-aligned" button on a TimeIntervals table only when the file
+  // also contains at least one compatible TimeSeries. The button opens the view
+  // defaulting to the lightest series (fewest samples per channel, so it renders
+  // fastest); the view offers a picker to switch between the available series.
+  getLaunchSecondaryPaths: ({ path, objectType, neurodataObjects }) => {
+    if (objectType !== "group") return [];
+    const primary = neurodataObjects.find((o) => o.path === path);
+    if (!primary) return [];
+    if (primary.attrs?.["neurodata_type"] !== "TimeIntervals") return [];
+    const seriesObjs = neurodataObjects.filter(
+      (o) => o.group && isTimeSeriesLikeGroup(o.group.datasets),
+    );
+    if (seriesObjs.length === 0) return [];
+    seriesObjs.sort(
+      (a, b) =>
+        timeSeriesSamplesPerChannel(a.group!.datasets) -
+        timeSeriesSamplesPerChannel(b.group!.datasets),
+    );
+    return [[seriesObjs[0].path]];
+  },
+  component: TimeAlignedSeriesView,
+  // Launch from a dedicated button next to the object (like PSTH) rather than
+  // rendering inline alongside the main timeseries view.
+  launchableFromTable: true,
+  requiresWindowDimensions: true,
+};
+
+export default timeAlignedSeriesPlugin;

--- a/src/pages/NwbPage/plugins/TimeAlignedSeries/loadTimeAlignedSnippets.ts
+++ b/src/pages/NwbPage/plugins/TimeAlignedSeries/loadTimeAlignedSnippets.ts
@@ -1,0 +1,90 @@
+import TimeseriesClient from "../simple-timeseries/TimeseriesClient";
+
+export type AlignedTrial = {
+  // Row index into the intervals table (preserved so group-by values can be
+  // matched per row without reloading the snippet data).
+  index: number;
+  // Times relative to the alignment event (seconds).
+  times: number[];
+  // Signal values for a single channel over the snippet.
+  roiValues: number[];
+};
+
+// Extract short snippets of a single channel of a TimeSeries around each
+// alignment time. Each snippet spans [alignTime + windowStart, alignTime +
+// windowEnd] and its timestamps are shifted so that the alignment event sits at
+// t = 0. Reads are issued with a small amount of concurrency to stay responsive
+// without overwhelming the remote HDF5 reader.
+export const loadTimeAlignedSnippets = async (
+  client: TimeseriesClient,
+  alignTimes: number[],
+  channel: number,
+  windowRange: { start: number; end: number },
+  opts: {
+    maxIntervals: number;
+    concurrency?: number;
+    canceler?: { canceled: boolean };
+    onProgress?: (loaded: number, total: number) => void;
+  },
+): Promise<AlignedTrial[]> => {
+  // Build the list of rows to load, keeping each row's original index (so
+  // group-by values still line up) and skipping rows whose alignment time is
+  // not finite (NaN alignment times are allowed in the table -- those rows are
+  // simply excluded for this alignment). The cap applies to valid rows.
+  const entries: { index: number; t: number }[] = [];
+  for (
+    let i = 0;
+    i < alignTimes.length && entries.length < opts.maxIntervals;
+    i++
+  ) {
+    const t = alignTimes[i];
+    if (isFinite(t)) entries.push({ index: i, t });
+  }
+
+  const trials: (AlignedTrial | undefined)[] = new Array(entries.length);
+  const concurrency = Math.max(
+    1,
+    Math.min(opts.concurrency ?? 8, entries.length),
+  );
+  // Report the true denominator (valid intervals to load) up front so the
+  // progress indicator never shows the raw max-intervals cap.
+  opts.onProgress?.(0, entries.length);
+  // Clamp the channel defensively; the selected series may have fewer channels.
+  const ch = Math.max(0, Math.min(channel, client.numChannels - 1));
+
+  let nextIndex = 0;
+  let loaded = 0;
+
+  const worker = async () => {
+    for (;;) {
+      const k = nextIndex++;
+      if (k >= entries.length) break;
+      if (opts.canceler?.canceled) break;
+      const { index, t } = entries[k];
+      try {
+        const { timestamps, data } = await client.getDataForTimeRange(
+          t + windowRange.start,
+          t + windowRange.end,
+          ch,
+          ch + 1,
+        );
+        const values = data[0] || [];
+        trials[k] = {
+          index,
+          times: timestamps.map((ts) => ts - t),
+          roiValues: values,
+        };
+      } catch (err) {
+        // Skip an interval that fails to load (an out-of-range/NaN time or a
+        // transient read error) rather than failing the whole panel.
+        console.warn(`Skipping interval ${index} (t=${t}):`, err);
+      }
+      loaded += 1;
+      opts.onProgress?.(loaded, entries.length);
+    }
+  };
+
+  await Promise.all(Array.from({ length: concurrency }, () => worker()));
+
+  return trials.filter((tr): tr is AlignedTrial => tr !== undefined);
+};

--- a/src/pages/NwbPage/plugins/pluginInterface.ts
+++ b/src/pages/NwbPage/plugins/pluginInterface.ts
@@ -1,4 +1,5 @@
 import { NwbFileSpecifications } from "../SpecificationsView/SetupNwbFileSpecificationsProvider";
+import type { NeurodataObject } from "../useNeurodataObjects";
 
 export interface NwbObjectViewPlugin {
   name: string;
@@ -11,6 +12,19 @@ export interface NwbObjectViewPlugin {
     secondaryPaths?: string[];
     specifications?: NwbFileSpecifications;
   }) => Promise<boolean>;
+  // Optionally derive candidate secondary object paths for a "launch from
+  // table" button from the full list of neurodata objects in the file. Returns
+  // one entry per launchable pairing (each a secondaryPaths array). This is for
+  // plugins whose secondary object cannot be inferred from the primary object
+  // alone (e.g. aligning a TimeSeries against a TimeIntervals table), so a
+  // button should appear only when a compatible partner exists. Each returned
+  // pairing is still validated with canHandle before a button is shown.
+  getLaunchSecondaryPaths?: (o: {
+    nwbUrl: string;
+    path: string;
+    objectType: "group" | "dataset";
+    neurodataObjects: NeurodataObject[];
+  }) => string[][] | Promise<string[][]>;
   // Component to render the view
   component: React.ComponentType<{
     nwbUrl: string;

--- a/src/pages/NwbPage/plugins/registry.ts
+++ b/src/pages/NwbPage/plugins/registry.ts
@@ -14,6 +14,7 @@ import {
 } from "./ImageSegmentation";
 import { timeIntervalsPlugin } from "./TimeIntervals";
 import { trialAlignedSeriesPlugin } from "./TrialAlignedSeries";
+import { timeAlignedSeriesPlugin } from "./TimeAlignedSeries";
 import { pythonScriptPlugin } from "./PythonScript";
 // import spikeDensityPlugin from "./SpikeDensity";
 import { intervalSeriesPlugin } from "./IntervalSeries";
@@ -44,6 +45,7 @@ export const nwbObjectViewPlugins: NwbObjectViewPlugin[] = [
   planeSegmentationPlugin,
   timeIntervalsPlugin,
   trialAlignedSeriesPlugin,
+  timeAlignedSeriesPlugin,
 
   poseEstimationPlugin,
   externalFileVideoPlugin,


### PR DESCRIPTION
Kind of like a PSTH, but for any source `TimeSeries` and any target `TimeIntervals`

Primarily for use in LFP analysis, but can also be useful for other things (including analog signals, movement patterns, `RoiResponseSeries`, etc.)

Check out these three examples:
- [Example 1](https://codycbakerphd.github.io/neurosift/previews/claude-time-aligned-timeseries-view-o3fm9c/nwb?url=https%3A%2F%2Fapi.dandiarchive.org%2Fapi%2Fassets%2F92e831a1-3427-4e06-9934-30d202bcc02d%2Fdownload%2F&dandisetId=000409&dandisetVersion=0.260309.1324&tab=view%3ATimeAlignedSeries%7C%2Fintervals%2Ftrials%5E%2Fprocessing%2Fmotion_energy%2FLeftCameraMotionEnergy#ta_series=%2Fprocessing%2Fmotion_energy%2FLeftCameraMotionEnergy&ta_groupby=gabor_stimulus_contrast&ta_align=auditory_cue_time&ta_win=-4%2C4)

- [Example 2](https://codycbakerphd.github.io/neurosift/previews/claude-time-aligned-timeseries-view-o3fm9c/nwb?url=https%3A%2F%2Fapi.dandiarchive.org%2Fapi%2Fassets%2F7a2d22aa-b7c3-43e6-a1e0-129a37bf8ffc%2Fdownload%2F&dandisetId=001539&dandisetVersion=0.250815.1203&tab=view%3ATimeAlignedSeries%7C%2Fintervals%2Ftrials%5E%2Fprocessing%2Fbehavior%2FPosition%2FSpatialSeries#ta_series=%2Fprocessing%2Fecephys%2FLFP%2FElectricalSeries&ta_align=reward_start_time&ta_channels=0%2C2%2C4)

- [Example 3](https://codycbakerphd.github.io/neurosift/previews/claude-time-aligned-timeseries-view-o3fm9c/nwb?url=https%3A%2F%2Fapi.dandiarchive.org%2Fapi%2Fassets%2Ffe5b6b44-12a6-4f59-a91f-953850564fb0%2Fdownload%2F&dandisetId=001637&dandisetVersion=draft&tab=view%3ATimeAlignedSeries%7C%2Fintervals%2F40+hz+pulse+train_presentations%5E%2Facquisition%2Fraw_running_wheel_rotation#ta_series=%2Fprocessing%2Fecephys%2FLFP%2FElectricalSeriesProbeD-LFP&ta_channels=5%2C22%2C25%2C32)


<details><summary>AI Summary</summary>

Adds a new NwbPage plugin, **Time-aligned**, that works like the PSTH but for continuous signals: it extracts **short snippets of any `TimeSeries` before and after each `_time` column of a `TimeIntervals` table**, overlays them across repetitions, and draws the trial-averaged trace on top.

Unlike the existing `TrialAlignedSeries` plugin (limited to `RoiResponseSeries` / `FiberPhotometryResponseSeries` / `MicroscopyResponseSeries`), this view fires for **any** timeseries-like object, so it can align LFP, behavioral signals, analog traces, etc. against trials, epochs, or any interval table.

## What's new

**`TimeAlignedSeries` plugin** (`src/pages/NwbPage/plugins/TimeAlignedSeries/`)
- **Detection** — `canHandle` matches a `TimeIntervals` primary paired with a single timeseries-like secondary: a group with a `data` dataset (1D single-channel or 2D time-by-channel) plus either `timestamps` or a regular `starting_time`.
- **Lazy snippet loading** — reuses the shared `TimeseriesClient` from `simple-timeseries` to read **only** the requested channel over each `[alignTime + windowStart, alignTime + windowEnd]` window, rather than pulling the whole series into the browser. This scales to large series (e.g. LFP). Reads run with bounded concurrency and a configurable per-column trial cap.
- **Rendering** — reuses the general `TrialAlignedSeriesWidget` (per-repetition traces + averaged trace, shared axis logic) and the existing `AlignTo` and `WindowRange` controls. Adds a channel selector and supports multiple align-to columns (one panel each). Each snippet's timestamps are shifted so the alignment event sits at t = 0.
- Registered in `registry.ts` next to `TrialAlignedSeries`.

Launch follows the same convention as `TrialAlignedSeries`: a `view:TimeAlignedSeries|<intervalsPath>^<timeseriesPath>` tab (a `TimeIntervals` object paired with a `TimeSeries`).


</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HaH4CmDAV93fjCQFdsHoLd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HaH4CmDAV93fjCQFdsHoLd)_